### PR TITLE
Fix typo in tests for Multinomial Logit case [revdep skip]

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipChart
 Type: Package
 Title: Single function for calling charts - CChart
-Version: 1.3.7
+Version: 1.3.8
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Wrapper for other chart functions, such that they can be access via a

--- a/tests/testthat/test-preparedata-regression-input-scatterplot.R
+++ b/tests/testthat/test-preparedata-regression-input-scatterplot.R
@@ -47,7 +47,7 @@ quasi.poisson.importance <- Regression(NumericAttitude ~ Beautiful + Carefree + 
                                        type = "Quasi-Poisson", output = "Relative Importance Analysis")
 multinomial.summary <- Regression(Attitude ~ Beautiful + Carefree + Charming + Confident + DownToEarth,
                                   data = stacked.cola.associations,
-                                  type = "Ordered Logit", output = "Summary")
+                                  type = "Multinomial Logit", output = "Summary")
 
 # table of regressor to add to regression
 large.performance.table <-
@@ -141,7 +141,7 @@ for (regression in importance.regression.types)
 for (regression in standard.regression.types)
     test_that(paste0("Test regression input X against table input Y: ", regression), {
         regression.to.input <- suppressWarnings(get(regression))
-        if(grepl("^(ordered|multinomial)", regression, perl = TRUE))
+        if(grepl("^ordered", regression, perl = TRUE, ignore.case = TRUE))
             warning.suffix <- "Don t Know"
         else
             warning.suffix <- "\\(Intercept\\)"
@@ -172,7 +172,7 @@ for (regression in importance.regression.types)
 for (regression in standard.regression.types)
     test_that(paste0("Test regression input X against table input Y: ", regression), {
         regression.to.input <- suppressWarnings(get(regression))
-        if(grepl("^(ordered|multinomial)", regression, perl = TRUE))
+        if(grepl("^ordered", regression, perl = TRUE))
             warning.suffix <- "Don t Know"
         else
             warning.suffix <- "\\(Intercept\\), Feminine"
@@ -205,7 +205,7 @@ for (regression in importance.regression.types)
 for (regression in standard.regression.types)
     test_that(paste0("Test regression input X against table input Y: ", regression), {
         regression.to.input <- suppressWarnings(get(regression))
-        if(grepl("^(ordered|multinomial)", regression, perl = TRUE))
+        if(grepl("^ordered", regression, perl = TRUE))
             warning.suffix <- "DownToEarth, Don t Know"
         else
             warning.suffix <- "\\(Intercept\\), DownToEarth"
@@ -238,7 +238,7 @@ for (regression in importance.regression.types)
 for (regression in standard.regression.types)
     test_that(paste0("Test table input X against regression input Y: ", regression), {
         regression.to.input <- suppressWarnings(get(regression))
-        if(grepl("^(ordered|multinomial)", regression, perl = TRUE))
+        if(grepl("^ordered", regression, perl = TRUE))
             warning.suffix <- "Don t Know"
         else
             warning.suffix <- "\\(Intercept\\)"
@@ -273,7 +273,7 @@ large.warning.suffix <- paste0("Feminine, Fun, Health-conscious, Hip, Honest, Hu
 for (regression in standard.regression.types)
     test_that(paste0("Test table input X against regression input Y: ", regression), {
         regression.to.input <- suppressWarnings(get(regression))
-        if(grepl("^(ordered|multinomial)", regression, perl = TRUE))
+        if(grepl("^ordered", regression, perl = TRUE))
             warning.suffix <- paste0(large.warning.suffix, "Don t Know")
         else
             warning.suffix <- paste0(large.warning.suffix, "\\(Intercept\\)")


### PR DESCRIPTION
Typo in the unit test for the changes to `PrepareData` for regression outputs. This commit fixes this change. The expected warning messages need to be updated as a result.