### PR TITLE
DS-2820 Allow more than one Y input for regression in Scatter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipChart
 Type: Package
 Title: Single function for calling charts - CChart
-Version: 1.4.7
+Version: 1.4.8
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Wrapper for other chart functions, such that they can be access via a

--- a/R/preparedata.R
+++ b/R/preparedata.R
@@ -744,7 +744,6 @@ coerceToDataFrame <- function(x, chart.type = "Column", remove.NULLs = TRUE)
             x[[2]] <- lapply(seq_along(x[[2]]), function(i) {
                 vals <- base.values
                 indices <- match(names(x[[2]][[i]]), y.all.rownames, nomatch = 0)
-                attr(x[[2]][[i]], "name") <- sub("^table.", "", attr(x[[2]][[i]], "name"))
                 vals[indices] <- x[[2]][[i]]
                 mostattributes(vals) <- attributes(x[[2]][[i]])
                 names(vals) <- y.all.rownames

--- a/R/preparedata.R
+++ b/R/preparedata.R
@@ -850,8 +850,12 @@ coerceToDataFrame <- function(x, chart.type = "Column", remove.NULLs = TRUE)
                 discarded.rows <- if(length(removed.rownames) == 0) NULL else {
                     paste0(": ", paste0(removed.rownames, collapse = ", "))
                 }
-                warning("Rows that did not occur in all of the input tables were discarded",
-                        discarded.rows)
+                if (any(reg.outputs))
+                    base.warning <- paste0("Y input coefficients that did not appear in the list of X input ",
+                                           "coefficients were discarded")
+                else
+                    base.warning <- "Rows that did not occur in all of the input tables were discarded"
+                warning(base.warning, discarded.rows)
             }
             if (length(rlabels) > 0)
                 warning("The 'Labels' variable has been ignored. Using row names of ",

--- a/tests/testthat/test-preparedata-regression-input-scatterplot.R
+++ b/tests/testthat/test-preparedata-regression-input-scatterplot.R
@@ -137,6 +137,9 @@ for (regression in importance.regression.types)
         expect_true(isValidPrepareData(pd))
     })
 
+base.warning <- paste0("Y input coefficients that did not appear in the list of X input ",
+                       "coefficients were discarded")
+
 # Expect warning about intercepts in table output
 for (regression in standard.regression.types)
     test_that(paste0("Test regression input X against table input Y: ", regression), {
@@ -145,7 +148,7 @@ for (regression in standard.regression.types)
             warning.suffix <- "Don t Know"
         else
             warning.suffix <- "\\(Intercept\\)"
-        expected.warning <- paste0("Rows that did not occur in all of the input tables were discarded: ",
+        expected.warning <- paste0(base.warning, ": ",
                                    warning.suffix)
         expect_warning(pd <- PrepareData(chart.type = "Scatter",
                                          input.data.raw = list(X = regression.to.input,
@@ -159,7 +162,7 @@ for (regression in standard.regression.types)
 for (regression in importance.regression.types)
     test_that(paste0("Test regression input X against table input Y: ", regression), {
         regression.to.input <- suppressWarnings(get(regression))
-        expected.warning <- paste0("Rows that did not occur in all of the input tables were discarded: ",
+        expected.warning <- paste0(base.warning, ": ",
                                    "Feminine, Fun, Health-conscious, Hip, Honest, Humorous, Imaginativ")
         expect_warning(pd <- PrepareData(chart.type = "Scatter",
                                          input.data.raw = list(X = regression.to.input,
@@ -176,7 +179,7 @@ for (regression in standard.regression.types)
             warning.suffix <- "Don t Know"
         else
             warning.suffix <- "\\(Intercept\\), Feminine"
-        expected.warning <- paste0("Rows that did not occur in all of the input tables were discarded: ",
+        expected.warning <- paste0(base.warning, ": ",
                                    warning.suffix)
         expect_warning(pd <- PrepareData(chart.type = "Scatter",
                                          input.data.raw = list(X = regression.to.input,
@@ -192,7 +195,7 @@ for (regression in standard.regression.types)
 for (regression in importance.regression.types)
     test_that(paste0("Test regression input X against table input Y: ", regression), {
         regression.to.input <- suppressWarnings(get(regression))
-        expected.warning <- paste0("Rows that did not occur in all of the input tables were discarded: ",
+        expected.warning <- paste0(base.warning, ": ",
                                    "DownToEarth")
         expect_warning(pd <- PrepareData(chart.type = "Scatter",
                                          input.data.raw = list(X = regression.to.input,
@@ -209,7 +212,7 @@ for (regression in standard.regression.types)
             warning.suffix <- "DownToEarth, Don t Know"
         else
             warning.suffix <- "\\(Intercept\\), DownToEarth"
-        expected.warning <- paste0("Rows that did not occur in all of the input tables were discarded: ",
+        expected.warning <- paste0(base.warning, ": ",
                                    warning.suffix)
         expect_warning(pd <- PrepareData(chart.type = "Scatter",
                                          input.data.raw = list(X = regression.to.input,
@@ -242,7 +245,7 @@ for (regression in standard.regression.types)
             warning.suffix <- "Don t Know"
         else
             warning.suffix <- "\\(Intercept\\)"
-        expected.warning <- paste0("Rows that did not occur in all of the input tables were discarded: ",
+        expected.warning <- paste0(base.warning, ": ",
                                    warning.suffix)
         expect_warning(pd <- PrepareData(chart.type = "Scatter",
                                          input.data.raw = list(X = performance.table,
@@ -256,7 +259,7 @@ for (regression in standard.regression.types)
 for (regression in importance.regression.types)
     test_that(paste0("Test table input X against regression input Y: ", regression), {
         regression.to.input <- suppressWarnings(get(regression))
-        expected.warning <- paste0("Rows that did not occur in all of the input tables were discarded: ",
+        expected.warning <- paste0(base.warning, ": ",
                                    "Feminine, Fun, Health-conscious, Hip, Honest, Humorous, Imaginativ")
         expect_warning(pd <- PrepareData(chart.type = "Scatter",
                                          input.data.raw = list(X = large.performance.table,
@@ -277,8 +280,7 @@ for (regression in standard.regression.types)
             warning.suffix <- paste0(large.warning.suffix, "Don t Know")
         else
             warning.suffix <- paste0(large.warning.suffix, "\\(Intercept\\)")
-        expected.warning <- paste0("Rows that did not occur in all of the input tables were discarded: ",
-                                   warning.suffix)
+        expected.warning <- paste0(base.warning, ": ", warning.suffix)
         expect_warning(pd <- PrepareData(chart.type = "Scatter",
                                          input.data.raw = list(X = large.performance.table,
                                                                Y = list(model = regression.to.input))),
@@ -309,7 +311,7 @@ for (reg.index  in seq_along(standard.regression.types))
                                      ", Feminine")
         else
             warning.suffix <- c("\\(Intercept\\), Feminine")
-        expected.warning <- paste0("^Rows that did not occur in all of the input tables were discarded: ",
+        expected.warning <- paste0(base.warning, ": ",
                                    warning.suffix)
         expect_warning(pd <- PrepareData(chart.type = "Scatter",
                                          input.data.raw = list(X = X.regression,
@@ -343,7 +345,7 @@ test_that("Multiple tables in Y with Regression in X", {
                                      input.data.raw = list(X = large.linear.importance,
                                                            Y = list(head.table,
                                                                     tail.table))),
-                   "^Rows that did not occur in all of the input tables were discarded")
+                   base.warning)
     expect_true(isValidPrepareData(pd))
 })
 


### PR DESCRIPTION
Previously having more than one Y input for a scatterplot that has a
regression model used in the inputs for either the X and Y coordinates
would throw an informative error. This commit allows the possibility of
having multiple Y inputs and gives an informative error message if there
is incompatible inputs in the X and Y coordinates. It does this by
checking the names of the points and matching accordingly.