### PR TITLE
DS-2820 Prevent error for single regression input

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipChart
 Type: Package
 Title: Single function for calling charts - CChart
-Version: 1.4.9
+Version: 1.4.10
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Wrapper for other chart functions, such that they can be access via a

--- a/R/preparedata.R
+++ b/R/preparedata.R
@@ -866,7 +866,7 @@ coerceToDataFrame <- function(x, chart.type = "Column", remove.NULLs = TRUE)
         }
     }
 
-    if (any(reg.outputs) && length(x.all.rownames) == 0)
+    if (any(reg.outputs) && length(x.all.rownames) == 0 && length(x) > 1)
     {
         x.names <- paste0(sQuote(names(x[[1]])), collapse = ", ")
         y.names <- paste0(sQuote(rownames(x[[2]])), collapse = ", ")

--- a/tests/testthat/test-preparedata-regression-input-scatterplot.R
+++ b/tests/testthat/test-preparedata-regression-input-scatterplot.R
@@ -412,3 +412,16 @@ test_that("Handle incompatible inputs properly", {
                        paste(sQuote(c(other.regression.vars, large.regression.vars)), collapse = ", ")),
                  fixed = TRUE)
 })
+
+test_that("Handle single inputs correctly", {
+    # Single regression object input in X position
+    expect_error(pd <- PrepareData(chart.type = "Scatter",
+                                   input.data.raw = list(X = linear.importance, Y = NULL)),
+                 NA)
+    expect_true(isValidPrepareData(pd))
+    # Single regression object input in Y position
+    expect_error(pd <- PrepareData(chart.type = "Scatter",
+                                   input.data.raw = list(X = NULL, Y = list(a = linear.importance))),
+                 NA)
+    expect_true(isValidPrepareData(pd))
+})


### PR DESCRIPTION
Previous commit for handling regression inputs to X and Y coordinated allowed more general input possibilities and handled errors but didnt consider case of single X or Y input which currently throws an error. This commit allows this case and adds unit tests.