### PR TITLE
DS-2820 Ensure labels are preserved from ChartData

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipChart
 Type: Package
 Title: Single function for calling charts - CChart
-Version: 1.4.11
+Version: 1.4.12
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Wrapper for other chart functions, such that they can be access via a

--- a/R/preparedata.R
+++ b/R/preparedata.R
@@ -1741,7 +1741,8 @@ convertScatterMultYvalsToDataFrame <- function(data, input.data.raw, show.labels
         y.names <- colnames(data)[y.ind]
     if (length(y.names) < m)
         y.names <- paste("Group", 1:m)
-
+    if (any(checkRegressionOutput(input.data.raw)) && length(y.names) >= m)
+        y.names <- colnames(data)[y.ind]
     extravar <- NULL
     if (length(dim(data)) <= 2)
         yvar <- as.vector(unlist(data[,y.ind]))
@@ -1760,7 +1761,7 @@ convertScatterMultYvalsToDataFrame <- function(data, input.data.raw, show.labels
 
     if (length(extravar) > 0)
         newdata <- cbind(newdata, extravar)
-    if (any(reg.outputs) && m > 1)
+    if (any(checkRegressionOutput(input.data.raw)) && m >= 1)
         rownames(newdata) <- MakeUniqueNames(rep(rownames(data), m))
     if (!grepl("^No date", date.format) && date.format != "Automatic")
     {


### PR DESCRIPTION
The labels in the chart data being passed into scatterplots from
regression inputs would sometimes lose their labels. This commit fixes
this and adds unit tests to check the labels havent been lost from the
chart data in all the relevant tests.