### PR TITLE
DS-2894: Scatterplot hover text only shown if appropriate

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipChart
 Type: Package
 Title: Single function for calling charts - CChart
-Version: 1.4.13
+Version: 1.4.14
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Wrapper for other chart functions, such that they can be access via a

--- a/R/preparedata.R
+++ b/R/preparedata.R
@@ -1707,6 +1707,7 @@ extractRegressionScatterData <- function(x, y.axis = FALSE, name = NULL)
 
 convertScatterMultYvalsToDataFrame <- function(data, input.data.raw, show.labels, date.format)
 {
+    data.row.labels <- rownames(data)
     n <- nrow(data)
     if (any(reg.outputs <- sapply(input.data.raw$Y, function(e) inherits(e, "Regression"))))
     {
@@ -1732,6 +1733,7 @@ convertScatterMultYvalsToDataFrame <- function(data, input.data.raw, show.labels
         m <- ncol(data)
         y.ind <- 1:m
         xvar <- rep(rownames(data), m)
+        data.row.labels <- rep("", nrow(data))
     } else
     {
         # Otherwise use first column as X-coordinates
@@ -1739,6 +1741,9 @@ convertScatterMultYvalsToDataFrame <- function(data, input.data.raw, show.labels
         y.ind <- (1:m) + 1
         xvar <- rep(data[,1], m)
     }
+    if (!hasUserSuppliedRownames(data))
+        data.row.labels <- rep("", nrow(data))
+
     if (length(y.names) < m)
         y.names <- colnames(data)[y.ind]
     if (length(y.names) < m)
@@ -1753,7 +1758,7 @@ convertScatterMultYvalsToDataFrame <- function(data, input.data.raw, show.labels
         yvar <- as.vector(unlist(data[,y.ind,1]))
         extravar <- apply(data[, y.ind, -1, drop = FALSE], 3, unlist)
     }
-
+    
     # newdata needs to use data rather than input.data.raw
     # otherwise it will not handle filters etc
     newdata <- data.frame(X = xvar,
@@ -1763,8 +1768,7 @@ convertScatterMultYvalsToDataFrame <- function(data, input.data.raw, show.labels
 
     if (length(extravar) > 0)
         newdata <- cbind(newdata, extravar)
-    if (any(checkRegressionOutput(input.data.raw)) && m >= 1)
-        rownames(newdata) <- MakeUniqueNames(rep(rownames(data), m))
+    rownames(newdata) <- MakeUniqueNames(rep(data.row.labels, m))
     if (!grepl("^No date", date.format) && date.format != "Automatic")
     {
         if (IsDateTime(as.character(newdata[,1])))

--- a/R/preparedata.R
+++ b/R/preparedata.R
@@ -1705,6 +1705,20 @@ extractRegressionScatterData <- function(x, y.axis = FALSE, name = NULL)
     return(chart.data)
 }
 
+
+# This function is used when scatter.mult.yvals = TRUE
+# It converts the input data frame which a data series in each column
+# into a the standard input format, where the data series
+# is indicated by the value in the "Groups" column
+# If x-coordinates are supplied in input.data.raw$X, then
+# rownames attached to the x-coordinates will be used as
+# rownames of the resulting data frame
+# Otherwise, the rownames of data will be used as the 
+# x-coordinates and the rownames of the output data
+# will be blank (with spaces as padding for uniqueness)
+# This function also updates the attribute "scatter.variable.indices"
+# to describe the format of the output data frame
+
 convertScatterMultYvalsToDataFrame <- function(data, input.data.raw, show.labels, date.format)
 {
     data.row.labels <- rownames(data)

--- a/tests/testthat/test-preparedata.R
+++ b/tests/testthat/test-preparedata.R
@@ -728,6 +728,7 @@ test_that("PrepareData: input and output format of raw data",
     expect_true(attr(res6$data, "scatter.mult.yvals"))
     expect_equal(res6$scatter.variable.indices, c(x = 1, y = 2, sizes = 0, colors = 3, groups = 3))
     expect_equal(as.character(res6$data[101,3]), "VarC")
+    expect_equal(sum(nchar(trimws(rownames(res6$data)))), 0)
 
     expect_warning(res7 <- PrepareData("Scatter", input.data.raw = list(X = xx, Y = list(yy, y2)),
         tidy.labels = TRUE, transpose = TRUE))
@@ -1373,10 +1374,12 @@ test_that("Scatter input data column order",
 
     res <- PrepareData("Scatter", input.data.other = tb, scatter.mult.yvals = TRUE)
     expect_equal(dim(res$data), c(30, 3))
+    expect_equal(sum(nchar(trimws(rownames(res$data)))), 0)
     expect_equal(attr(res$data, "scatter.mult.yvals"), TRUE)
     res <- PrepareData("Scatter", input.data.pasted = pst, scatter.mult.yvals = TRUE)
     expect_equal(levels(res$data$Groups), c('B','C'))
     res <- PrepareData("Scatter", input.data.pasted = p.dates, date.format = "International", scatter.mult.yvals = TRUE)
+    expect_equal(sum(nchar(trimws(rownames(res$data)))), 0)
     expect_equal(res$data[,1], sprintf("Jan %02d 2017", c(1:4, 1:4)))
     res <- PrepareData("Scatter", input.data.pasted = p.unnamed, scatter.mult.yvals = TRUE)
     expect_equal(levels(res$data$Groups), c('Group 1','Group 2'))
@@ -1484,7 +1487,8 @@ test_that("PrepareData with lists and dataframes",
         pop15 = c(30.35, 24.32, 24.8, 42.89, 43.19)), .Names = c("sr",
         "pop15"), row.names = c("Australia", "Austria", "Belgium",
         "Bolivia", "Brazil"), class = "data.frame"))
-    expect_silent(PrepareData("Scatter", input.data.table = dfL))
+    expect_silent(res <- PrepareData("Scatter", input.data.table = dfL))
+    expect_equal(rownames(res$data[[2]]), rownames(dfL[[2]]))
 })
 
 test_that("Heatmap allows numeric rownames",
@@ -1798,6 +1802,10 @@ test_that("Scatter accepts tables as variables",
     pd <- PrepareData("Scatter", input.data.raw = raw.named)
     expect_equal(dim(pd$data), c(16, 3))
     expect_equal(levels(pd$data[,3]), c("Male", "Female"))
+    expect_equal(rownames(pd$data), c("Coca-Cola", "Diet Coke", "Coke Zero", "Pepsi ", "Diet Pepsi",
+        "Pepsi Max", "Dislike all cola", "Don't care", "Coca-Cola ",
+        "Diet Coke ", "Coke Zero ", "Pepsi  ", "Diet Pepsi ", "Pepsi Max ",
+        "Dislike all cola ", "Don't care "))
 
     raw.unordered <- list(X = structure(1:6, .Names = c("a", "b", "c", "d", "e", "f"
     )), Y = list(v2 = structure(1:6, .Names = c("f", "e", "d", "c",
@@ -1851,6 +1859,13 @@ test_that("Scatter accepts tables as variables",
     expect_warning(pd <- PrepareData("Scatter", input.data.raw = raw.2dtable))
     expect_equal(dim(pd$data), c(30, 3))
     expect_equal(colnames(pd$data)[1], "Hate")
+    expect_equal(rownames(pd$data), c("Coca-Cola", "Diet Coke", "Coke Zero", "Pepsi", "Diet Pepsi",
+        "Pepsi Max", "Coca-Cola ", "Diet Coke ", "Coke Zero ", "Pepsi ",
+        "Diet Pepsi ", "Pepsi Max ", "Coca-Cola  ", "Diet Coke  ", "Coke Zero  ",
+        "Pepsi  ", "Diet Pepsi  ", "Pepsi Max  ", "Coca-Cola   ", "Diet Coke   ",
+        "Coke Zero   ", "Pepsi   ", "Diet Pepsi   ", "Pepsi Max   ",
+        "Coca-Cola    ", "Diet Coke    ", "Coke Zero    ", "Pepsi    ",
+        "Diet Pepsi    ", "Pepsi Max    "))
 
     raw.multiY.and.size <- list(X = structure(c(`Coca-Cola` = 42.625, `Diet Coke` = 11.125,
     `Coke Zero` = 17.875, `Pepsi ` = 9, `Diet Pepsi` = 2.5, `Pepsi Max` = 14.875,
@@ -1931,6 +1946,7 @@ test_that("Scatter accepts tables as variables",
             Z2 = NULL, groups = NULL, labels = NULL)
     pd <- PrepareData("Scatter", input.data.raw = raw.multi.ytable)
     expect_equal(nlevels(pd$data$Groups), sum(sapply(raw.multi.ytable$Y, ncol)) - 2)
+    expect_equal(rownames(pd$data), MakeUniqueNames(rep(rownames(raw.multi.ytable$X)[2:10], 11)))
 
 
     raw.ytable.only <- list(X = NULL, Y = list(`Preferred cola` = structure(c(`Coca-Cola` = 42.625,
@@ -1943,7 +1959,7 @@ test_that("Scatter accepts tables as variables",
     pd <- PrepareData("Scatter", input.data.raw = raw.ytable.only)
     expect_equal(dim(pd$data), c(8, 1))
     expect_equal(pd$scatter.variable.indices, c(NA, 1, NA, NA, NA), check.attributes = FALSE)
-
+    expect_equal(rownames(pd$data), names(raw.ytable.only$Y[[1]])[-9])
 
     b.raw <- list(X = rep(c("Age", "Gender", "Location"), c(8, 3, 9)),
     Y = list(b1 = structure(c(5.29313929313929, 5.57701421800948,


### PR DESCRIPTION
This PR is trying to (1) Remove hover text when its not appropriate (usually showing the index values of the row number) and (2) Retain rownames if they are supplied in the input X or Y coordinates