### PR TITLE
DS-3830: Ensuring subscripted QTables play nicely with visualizations

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipChart
 Type: Package
 Title: Single function for calling charts - CChart
-Version: 1.9.6
+Version: 1.9.7
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Wrapper for other chart functions, such that they can be access via a

--- a/R/cchart.R
+++ b/R/cchart.R
@@ -279,7 +279,7 @@ CChart <- function(chart.type, x, small.multiples = FALSE,
 
     # Try to set up data to show statistical significance
     # Or give warning message if input data does not contain info
-    if (signif.show && is.null(attr(x, "questions", exact = TRUE)))
+    if (signif.show && is.null(attr(x, "questions", exact = TRUE)) && is.null(attr(x, "original.questions", exact = TRUE)))
         warning("Significance tests cannot be shown as the input data is not a summary table or crosstab")
     else if (signif.show && is.null(attr(x, "QStatisticsTestingInfo", exact = TRUE)))
         warning("Significance tests cannot be shown on this version of Q")


### PR DESCRIPTION
Permit check for original.questions in CChart. CChart checks for the "questions" attribute, presumably to verify that the input comes from a QTable. A subscripted QTable will have "original.questions" instead.