### PR TITLE
untracked! coerce flattened to matrix

### DIFF
--- a/R/preparedata.R
+++ b/R/preparedata.R
@@ -1276,7 +1276,7 @@ RearrangeRowsColumns <- function(data,
                                  sort.columns, sort.columns.decreasing, sort.columns.row,
                                  sort.columns.exclude, reverse.columns)
 {
-    if (is(data, "ftable")) data <- as.matrix(data)
+    if (inherits(data, "ftable")) data <- as.matrix(data)
     if (multiple.tables)
     {
         for(i in seq_along(data))

--- a/R/preparedata.R
+++ b/R/preparedata.R
@@ -1038,7 +1038,6 @@ processInputData <- function(x, subset, weights)
             x <- flattenMultiStatTable(x)
         else
             x <- FlattenTableAndDropStatisticsIfNecessary(x)
-        class(x) <- c("matrix", "array")
     }
 
     if (hasUserSuppliedRownames(x))
@@ -1277,6 +1276,7 @@ RearrangeRowsColumns <- function(data,
                                  sort.columns, sort.columns.decreasing, sort.columns.row,
                                  sort.columns.exclude, reverse.columns)
 {
+    if (is(data, "ftable")) data <- as.matrix(data)
     if (multiple.tables)
     {
         for(i in seq_along(data))
@@ -1773,7 +1773,7 @@ setAxisTitles <- function(x, chart.type, drop, values.title = "")
             if (dim(x)[2] == 1) {
                 tmp.vec <- x[, 1]
                 names(tmp.vec) <- rownames(x)
-            } 
+            }
             else if (dim(x)[1] == 1) {
                 tmp.vec <- x[1, ]
                 names(tmp.vec) <- colnames(x)
@@ -1783,7 +1783,7 @@ setAxisTitles <- function(x, chart.type, drop, values.title = "")
             attr(tmp.vec, "categories.title") <- attr(x, "categories.title")
             attr(tmp.vec, "values.title") <- attr(x, "values.title")
             x <- tmp.vec
-        } 
+        }
         else
             x <- CopyAttributes(drop(x), x)
     }
@@ -2229,4 +2229,3 @@ addStatTesting <- function(x, x.siginfo, p.cutoffs, colors.pos, colors.neg, symb
     attr(new.dat, "signif-annotations") <- annot.list
     return(new.dat)
 }
-

--- a/R/preparedata.R
+++ b/R/preparedata.R
@@ -1038,6 +1038,7 @@ processInputData <- function(x, subset, weights)
             x <- flattenMultiStatTable(x)
         else
             x <- FlattenTableAndDropStatisticsIfNecessary(x)
+        class(x) <- c("matrix", "array")
     }
 
     if (hasUserSuppliedRownames(x))

--- a/tests/testthat/test-preparedata.R
+++ b/tests/testthat/test-preparedata.R
@@ -2773,14 +2773,16 @@ test_that("DS-3842 - QTable attribute interferes with structure of data",
     names(expected) <- c("3", "1", "5", "2", "4")
     expect_equivalent(pd$data, expected)
     }
-    
+
     tb.with.gridq.QTable <- tb.with.gridq
     class(tb.with.gridq.QTable) <- c(class(tb.with.gridq.QTable), "QTable")
     summary.table.QTable <- summary.table
     class(summary.table.QTable) <- c(class(summary.table.QTable), "QTable")
     for (ct in c("Box", "Bar", "Scatter")) {
-        expect_equivalent(PrepareData(ct, input.data.table = tb.with.gridq.QTable, tidy = FALSE, select.rows = "", select.columns = "")$data,
-                        PrepareData(ct, input.data.table = tb.with.gridq, tidy = FALSE, select.rows = "", select.columns = "")$data)        
+        wn <- if (ct == "Scatter") "only the first" else NA
+        expect_warning(pd1 <- PrepareData(ct, input.data.table = tb.with.gridq.QTable, tidy = FALSE, select.rows = "", select.columns = "")$data, wn)
+        expect_warning(pd2 <- PrepareData(ct, input.data.table = tb.with.gridq, tidy = FALSE, select.rows = "", select.columns = "")$data, wn)
+        expect_equivalent(pd1, pd2)
         expect_equivalent(PrepareData(ct, input.data.table = summary.table.QTable, tidy = FALSE, select.rows = "", select.columns = "")$data,
                         PrepareData(ct, input.data.table = summary.table, tidy = FALSE, select.rows = "", select.columns = "")$data)
     }


### PR DESCRIPTION
Coerce the flattened Q Table input data tables from class `ftable` to a matrix as the current implementation of `RemoveAt` does not recognise the `ftable` class and fails to operate on it properly.