### PR TITLE
DS-5360 Update PrepareData to not remove QTable class after SelectFromTable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ parameters:
     default: ""
   remote-deps:
     type: string
-    default: ""
+    default: "Displayr/verbs@DS-5360"
   plugins-branch:
     type: string
     default: ""

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ parameters:
   executor:
     type: enum
     enum: [nightly, rocker, machine,rocker-geo]
-    default: rocker
+    default: nightly
 
 workflows:
   build-and-check-R-package:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ parameters:
     default: ""
   remote-deps:
     type: string
-    default: "Displayr/verbs@DS-5360"
+    default: ""
   plugins-branch:
     type: string
     default: ""

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Imports:
     flipTime,
     flipTransformations (>= 1.10.0),
     flipU (>= 1.5.5),
-    verbs (>= 0.14.18)
+    verbs (>= 0.15.9)
 Remotes:
     Displayr/plotly,
     Displayr/flipChartBasics,

--- a/R/preparedata.R
+++ b/R/preparedata.R
@@ -2315,7 +2315,7 @@ unclassQTable <- function(data)
         class(data) <- setdiff(original.class, "QTable")
         return(data)
     }
-    if (IsQTable(data))
+    if (IsQTable(data) && isFALSE(attr(data, "table.select.subscripted")))
     {
         data <- unclass(data)
         data.attributes <- attributes(data)

--- a/R/preparedata.R
+++ b/R/preparedata.R
@@ -2315,7 +2315,7 @@ unclassQTable <- function(data)
         class(data) <- setdiff(original.class, "QTable")
         return(data)
     }
-    if (IsQTable(data) && isFALSE(attr(data, "table.select.subscripted")))
+    if (IsQTable(data) && is.null(attr(data, "table.select.subscripted")))
     {
         data <- unclass(data)
         data.attributes <- attributes(data)

--- a/tests/testthat/test-preparedata.R
+++ b/tests/testthat/test-preparedata.R
@@ -3027,7 +3027,7 @@ test_that("DS-5360 Subscripted Table Select outputs don't get nerfed", {
     )
     subscripted <- test.table[2:3, ]
     expect_true(attr(subscripted, "is.subscripted"))
-    subscripted.with.table.select <- SelectFromTable(
+    subscripted.with.table.select <- verbs::SelectFromTable(
         test.table,
         row.selection.mode = "range",
         row.selection = 2:3

--- a/tests/testthat/test-preparedata.R
+++ b/tests/testthat/test-preparedata.R
@@ -2720,7 +2720,8 @@ test_that("DS-3891 Ensure subscripted tables lose attributes in PrepareData", {
         original.name = "table.Q3.Age.in.years.2",
         name = "table.Q3.Age.in.years.2[1:2]",
         questions = c("Q3. Age in years", "SUMMARY"),
-        class = c("QTable", "qTable", "array"))
+        class = c("QTable", "qTable", "array")
+    )
 
     basic.table <- array(values, dimnames = list(qtable.names))
     basic.subscripted.table <- structure(array(values[1:2], dimnames = list(qtable.names[1:2])),
@@ -3023,6 +3024,7 @@ test_that("DS-5360 Subscripted Table Select outputs don't get nerfed", {
     test.table <- structure(
         array(1:12, dim = 3:4, dimnames = list(letters[1:3], LETTERS[1:4])),
         statistic = "%",
+        questiontypes = c("PickOne", "Numeric"),
         class = c("array", "QTable")
     )
     subscripted <- test.table[2:3, ]

--- a/tests/testthat/test-preparedata.R
+++ b/tests/testthat/test-preparedata.R
@@ -3042,6 +3042,8 @@ test_that("DS-5360 Subscripted Table Select outputs don't get nerfed", {
         chart.type = "Bar",
         input.data.table = subscripted.with.table.select
     )
+    # By default ALLOW.QTABLE.CLASS is not defined and will take the default of FALSE
+    # Therefore the attributes will be removed for a standard subscripted table
     expect_null(attr(regular.pd.with.subscripting[["data"]], "statistic"))
     expect_equal(attr(pd.with.table.select.subscripting[["data"]], "statistic"), "%")
     # Check data structure is same except for known difference


### PR DESCRIPTION
- DS-5360 Don't always remove QTable attributes in PrepareData
- DS-5360 Point to verbs@DS-5360 for tests
- use nightly container
- Ensure SelectFromTable available in tests:
- Fix tests
- Remove pointer to verbs@DS-5360 [ci skip]
