### PR TITLE
RS-15077: preserve color opacity when exporting

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipChart
 Type: Package
 Title: Single function for calling charts - CChart
-Version: 1.10.26
+Version: 1.10.27
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Wrapper for other chart functions, such that they can be access via a

--- a/R/cchart.R
+++ b/R/cchart.R
@@ -851,11 +851,11 @@ getHexCode <- function(color, opacity)
         return(sprintf("%s%02X", color, round(opacity * 255)))
     
     # Returns grey if color is not recognized - matches checkColors
-    tmp <- try(col2rgb(color, alpha = TRUE), silent)
-    if (inherits(tmp, "try-error"))
-        return ('#CCCCCC')
+    col.as.rgb <- try(t(col2rgb(color, alpha = TRUE)), silent = TRUE)
+    if (inherits(col.as.rgb, "try-error"))
+        return("#CCCCCC")
     # If color is 8-digit hex than multiply opacity - matches plotly::toRGB
-    return(rgb(t(tmp), alpha = round(opacity * tmp["alpha",]), maxColorValue = 255))
+    return(rgb(col.as.rgb, alpha = round(opacity * col.as.rgb[, "alpha"]), maxColorValue = 255))
 }
 
 # This function determines whether the font should be shown in black or white

--- a/R/cchart.R
+++ b/R/cchart.R
@@ -634,7 +634,7 @@ getPPTSettings <- function(chart.type, args, data)
         tmp.colors <- list()
         for (i in seq_along(args$colors))
             tmp.colors[[i]] <- list(Index = i - 1,
-                BackgroundColor = getHexCode(args$colors[i], round(tmp.opacity*255)))
+                BackgroundColor = getHexCode(args$colors[i], tmp.opacity))
         series.settings <- list(list(
             CustomPoints = tmp.colors,
             ShowDataLabels = tmp.data.label.show,
@@ -649,7 +649,7 @@ getPPTSettings <- function(chart.type, args, data)
     } else
         series.settings <- lapply(1:length(args$colors),
         function(i) {list(
-            BackgroundColor = getHexCode(args$colors[i], round(tmp.opacity*255)),
+            BackgroundColor = getHexCode(args$colors[i], tmp.opacity),
             ShowDataLabels = tmp.data.label.show,
             ShowCategoryNames = tmp.data.label.show.category.labels,
             DataLabelsFont = list(family = args$data.label.font.family,
@@ -666,7 +666,7 @@ getPPTSettings <- function(chart.type, args, data)
         for (i in 1:tmp.n)
             series.settings[[i]]$Marker = list(Size = args$marker.size,
                 OutlineStyle = "None",
-                BackgroundColor = getHexCode(args$colors[i], round(tmp.opacity*255)))
+                BackgroundColor = getHexCode(args$colors[i], tmp.opacity))
 
     # Initialise return output
     res <- list()
@@ -694,7 +694,7 @@ getPPTSettings <- function(chart.type, args, data)
             Position = legend.position)
     if (isTRUE(nchar(args$background.fill.color) > 0) &&
         args$background.fill.color != "transparent")
-        res$BackgroundColor <- getHexCode(args$background.fill.color, round(args$background.fill.opacity * 255))
+        res$BackgroundColor <- getHexCode(args$background.fill.color, args$background.fill.opacity)
 
     # Chart and Axis titles always seem to be ignored
     # Waiting on RS-7208
@@ -845,18 +845,18 @@ px2pt <- function(x)
 
 getHexCode <- function(color, opacity)
 {
-    if (substr(color, 0, 1) != '#' || !(opacity >= 0 && opacity <= 1))
+    if (!(opacity >= 0 && opacity < 1))
         return(color)
-    if (nchar(color) == 9)
-        return(color)
-    if (nchar(color) == 7)
-        return(sprintf("%s%02X", colors, round(opacity * 255)))
-    if (nchar(color) == 4)
-    {
-        hex <- strsplit(color, "")[[1]]
-        return(sprintf("#%s%s%s%s%s%s%02X", hex[2], hex[2], hex[3], hex[3], 
-            hex[4], hex[4], round(opacity * 255)))
-    }
+    if (substr(color, 0, 1) == '#' && nchar(color) == 7)
+        return(sprintf("%s%02X", color, round(opacity * 255)))
+    
+    # Returns grey if color is not recognized - matches checkColors
+    tmp <- try(col2rgb(color, alpha = TRUE), silent)
+    if (inherits(tmp, "try-error"))
+        return ('#CCCCCC')
+    # If color is 8-digit hex than multiply opacity - matches plotly::toRGB
+    return(rgb(t(tmp), alpha = opacity * tmp["alpha",], maxColorValue = 255)
+
 }
 
 # This function determines whether the font should be shown in black or white

--- a/R/cchart.R
+++ b/R/cchart.R
@@ -561,7 +561,7 @@ getPPTSettings <- function(chart.type, args, data)
     if (chart.type %in% c("Pie", "Donut"))
         tmp.line.color <- args$pie.border.color
     else if (!is.null(args$marker.border.opacity))
-        tmp.line.color <- args$marker.border.color
+        tmp.line.color <- getHexCode(args$marker.border.color, args$marker.border.opacity)
     if (is.null(tmp.line.color) || all(is.na(tmp.line.color)))
         tmp.line.color <- "#FFFFFF"
     tmp.line.color <- rep(tmp.line.color, length = tmp.n)
@@ -633,8 +633,8 @@ getPPTSettings <- function(chart.type, args, data)
         # with many CustomPoints
         tmp.colors <- list()
         for (i in seq_along(args$colors))
-            tmp.colors[[i]] <- list(Index = i - 1,
-                BackgroundColor = getHexCode(args$colors[i], tmp.opacity))
+            tmp.colors[[i]] <- list(BackgroundColor = getHexCode(args$colors[i], tmp.opacity),
+                    Index = i - 1)
         series.settings <- list(list(
             CustomPoints = tmp.colors,
             ShowDataLabels = tmp.data.label.show,
@@ -845,7 +845,7 @@ px2pt <- function(x)
 
 getHexCode <- function(color, opacity)
 {
-    if (!(opacity >= 0 && opacity < 1))
+    if (!(opacity >= 0 && opacity <= 1))
         return(color)
     if (substr(color, 0, 1) == '#' && nchar(color) == 7)
         return(sprintf("%s%02X", color, round(opacity * 255)))
@@ -855,7 +855,7 @@ getHexCode <- function(color, opacity)
     if (inherits(tmp, "try-error"))
         return ('#CCCCCC')
     # If color is 8-digit hex than multiply opacity - matches plotly::toRGB
-    return(rgb(t(tmp), alpha = opacity * tmp["alpha",], maxColorValue = 255)
+    return(rgb(t(tmp), alpha = round(opacity * tmp["alpha",]), maxColorValue = 255))
 
 }
 

--- a/R/cchart.R
+++ b/R/cchart.R
@@ -856,7 +856,6 @@ getHexCode <- function(color, opacity)
         return ('#CCCCCC')
     # If color is 8-digit hex than multiply opacity - matches plotly::toRGB
     return(rgb(t(tmp), alpha = round(opacity * tmp["alpha",]), maxColorValue = 255))
-
 }
 
 # This function determines whether the font should be shown in black or white

--- a/R/cchart.R
+++ b/R/cchart.R
@@ -633,8 +633,8 @@ getPPTSettings <- function(chart.type, args, data)
         # with many CustomPoints
         tmp.colors <- list()
         for (i in seq_along(args$colors))
-            tmp.colors[[i]] <- list(BackgroundColor = sprintf("%s%X",
-                args$colors[i], round(tmp.opacity*255)), Index = i - 1)
+            tmp.colors[[i]] <- list(Index = i - 1,
+                BackgroundColor = getHexCode(args$colors[i], round(tmp.opacity*255)))
         series.settings <- list(list(
             CustomPoints = tmp.colors,
             ShowDataLabels = tmp.data.label.show,
@@ -649,7 +649,7 @@ getPPTSettings <- function(chart.type, args, data)
     } else
         series.settings <- lapply(1:length(args$colors),
         function(i) {list(
-            BackgroundColor = sprintf("%s%X", args$colors[i], round(tmp.opacity*255)),
+            BackgroundColor = getHexCode(args$colors[i], round(tmp.opacity*255)),
             ShowDataLabels = tmp.data.label.show,
             ShowCategoryNames = tmp.data.label.show.category.labels,
             DataLabelsFont = list(family = args$data.label.font.family,
@@ -666,7 +666,7 @@ getPPTSettings <- function(chart.type, args, data)
         for (i in 1:tmp.n)
             series.settings[[i]]$Marker = list(Size = args$marker.size,
                 OutlineStyle = "None",
-                BackgroundColor = sprintf("%s%X", args$colors[i], round(tmp.opacity*255)))
+                BackgroundColor = getHexCode(args$colors[i], round(tmp.opacity*255)))
 
     # Initialise return output
     res <- list()
@@ -694,8 +694,7 @@ getPPTSettings <- function(chart.type, args, data)
             Position = legend.position)
     if (isTRUE(nchar(args$background.fill.color) > 0) &&
         args$background.fill.color != "transparent")
-        res$BackgroundColor <- sprintf("%s%X", args$background.fill.color,
-                                       round(args$background.fill.opacity * 255))
+        res$BackgroundColor <- getHexCode(args$background.fill.color, round(args$background.fill.opacity * 255))
 
     # Chart and Axis titles always seem to be ignored
     # Waiting on RS-7208
@@ -844,6 +843,21 @@ px2pt <- function(x)
     return(x/1.3333)
 }
 
+getHexCode <- function(color, opacity)
+{
+    if (substr(color, 0, 1) != '#' || !(opacity >= 0 && opacity <= 1))
+        return(color)
+    if (nchar(color) == 9)
+        return(color)
+    if (nchar(color) == 7)
+        return(sprintf("%s%02X", colors, round(opacity * 255)))
+    if (nchar(color) == 4)
+    {
+        hex <- strsplit(color, "")[[1]]
+        return(sprintf("#%s%s%s%s%s%s%02X", hex[2], hex[2], hex[3], hex[3], 
+            hex[4], hex[4], round(opacity * 255)))
+    }
+}
 
 # This function determines whether the font should be shown in black or white
 # on the brightness of background. The coefficients are the same as in

--- a/R/cchart.R
+++ b/R/cchart.R
@@ -847,9 +847,9 @@ getHexCode <- function(color, opacity)
 {
     if (!(opacity >= 0 && opacity <= 1))
         return(color)
-    if (substr(color, 0, 1) == '#' && nchar(color) == 7)
+    if (startsWith(color, "#") && nchar(color) == 7)
         return(sprintf("%s%02X", color, round(opacity * 255)))
-    
+
     # Returns grey if color is not recognized - matches checkColors
     col.as.rgb <- try(t(col2rgb(color, alpha = TRUE)), silent = TRUE)
     if (inherits(col.as.rgb, "try-error"))

--- a/tests/testthat/test-chartsettings.R
+++ b/tests/testthat/test-chartsettings.R
@@ -187,7 +187,7 @@ test_that("Chart settings",
             Index = 7), list(BackgroundColor = "#EC83BAB2", Index = 8),
             list(BackgroundColor = "#999999B2", Index = 9)))
     expect_equal(attr(res, "ChartSettings")$TemplateSeries[[1]]$OutlineStyle, "Solid")
-    expect_equal(attr(res, "ChartSettings")$TemplateSeries[[1]]$OutlineColor, "#FF0000")
+    expect_equal(attr(res, "ChartSettings")$TemplateSeries[[1]]$OutlineColor, "#FF0000FF")
     expect_equal(attr(res, "ChartSettings")$TemplateSeries[[1]]$OutlineWidth, 0.750018750468762)
     expect_equal(attr(res, "ChartSettings")$GapWidth, 40)
     expect_equal(attr(res, "ChartSettings")$ShowLegend, FALSE)
@@ -303,3 +303,14 @@ test_that("Legend position",
     expect_equal(attr(viz, "ChartSettings")$Legend$Position, "Right")
 })
 
+test_that("Color opacity",
+{
+    viz <- CChart("Bar", dat.2d, append.data = TRUE,
+        colors=c("#FF000080", "#00FF00", "blue"), opacity = 0.05,
+        marker.border.width = 2, marker.border.color = "#222222", marker.border.opacity = 0.5)
+    expect_equal(attr(viz, "ChartSettings")$TemplateSeries[[1]]$BackgroundColor, "#FF000006")
+    expect_equal(attr(viz, "ChartSettings")$TemplateSeries[[2]]$BackgroundColor, "#00FF000D")
+    expect_equal(attr(viz, "ChartSettings")$TemplateSeries[[3]]$BackgroundColor, "#0000FF0D")
+    expect_equal(attr(viz, "ChartSettings")$TemplateSeries[[3]]$OutlineColor, "#22222280")
+    expect_equal(attr(viz, "ChartSettings")$TemplateSeries[[3]]$OutlineWidth, 1.500, tol = 1e-3)
+})


### PR DESCRIPTION
Previously exporting to PPT with opacity (set via the numericUpDown control) only worked on 6 digit hex colors, but the chart itself in Displayr can deal with 8 digit hex and named colors (e.g. "blue")