### PR TITLE
DDS-1241: Paste or Enter Tables should preserve spans

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipChart
 Type: Package
 Title: Single function for calling charts - CChart
-Version: 1.10.27
+Version: 1.10.28
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Wrapper for other chart functions, such that they can be access via a

--- a/R/preparedata.R
+++ b/R/preparedata.R
@@ -574,13 +574,17 @@ PrepareData <- function(chart.type,
     if (!is.null(input.data.table))
         attr(data, "footerhtml") <- attr(input.data.table, "footerhtml", exact = TRUE)
 
-    list(data = data,
+    res <- list(data = data,
          weights = weights,
          values.title = values.title,
          categories.title = categories.title,
          chart.title = chart.title,
          chart.footer = attr(data, "footer", exact = TRUE),
          scatter.variable.indices = attr(data, "scatter.variable.indices"))
+    span <- attr(data, "span", exact = TRUE)
+    if (!is.null(span))
+        attr(res, "span") <- span
+    return (res)
 }
 
 replaceDimNames <- function(x, dim, labels)
@@ -1393,12 +1397,15 @@ transformTable <- function(data,
     # hide.rows.threshold and row.names.to.remove refer to rows AFTER tranposing
     if (isTRUE(transpose))
     {
+        old.span <- attr(data, "span", exact = TRUE)
         if (length(dim(data)) > 2)
             new.data <- aperm(data, c(2, 1, 3))
         else
             new.data <- t(data)
         data <- CopyAttributes(new.data, data)
         attr(data, "questions") <- rev(attr(data, "questions"))
+        if (!is.null(old.span))
+            attr(data, "span") <- list(rows = old.span$columns, columns = old.span$rows)
     }
 
     # Checking sample sizes (if available)

--- a/R/preparedata.R
+++ b/R/preparedata.R
@@ -334,6 +334,8 @@ PrepareData <- function(chart.type,
                             input.data.raw, input.data.pasted, input.data.other)
     # Assign the data to 'data'
     data <- processInputData(input.data.table, subset, weights)
+    cat("line 336\n")
+    print(class(data))
     if (is.null(data))
         data <- input.data.tables
     if (is.null(data))
@@ -362,6 +364,7 @@ PrepareData <- function(chart.type,
         names(data) <- if (show.labels) Labels(data) else Names(data)
     chart.title <- attr(data, "title")
     cat("line 364\n")
+    print(class(data))
     print(attr(data, "span"))
 
     ###########################################################################
@@ -406,6 +409,7 @@ PrepareData <- function(chart.type,
     if (filt)
         attr(data, "assigned.rownames") <- FALSE
     cat("line 408\n")
+    print(class(data))
     print(attr(data, "span"))
 
     ###########################################################################
@@ -433,6 +437,7 @@ PrepareData <- function(chart.type,
             group.by.last <- TRUE
     }
     cat("line 435\n")
+    print(class(data))
     print(attr(data, "span"))
 
     ###########################################################################
@@ -474,6 +479,7 @@ PrepareData <- function(chart.type,
                    transpose, group.by.last || first.aggregate,
                    hide.empty.rows, hide.empty.columns, date.format)
     cat("line 476\n")
+    print(class(data))
     print(attr(data, "span"))
 
     # Sort must happen AFTER tidying
@@ -506,6 +512,7 @@ PrepareData <- function(chart.type,
     if (scatter.mult.yvals)
         data <- convertScatterMultYvalsToDataFrame(data, input.data.raw, show.labels, date.format)
     cat("line 508\n")
+    print(class(data))
     print(attr(data, "span"))
 
     ###########################################################################
@@ -1343,6 +1350,9 @@ RearrangeRowsColumns <- function(data,
     data <- RemoveRowsAndOrColumns(data,
                 row.names.to.remove = row.names.to.remove,
                 column.names.to.remove = column.names.to.remove, split = split)
+    cat("after RemoveRowsAndColumns\n")
+    print(class(data))
+    print(attr(data, "span"))
 
     # Keep last to retain order from sorting
     data <- SelectRows(data, first.k = first.k.rows, last.k = last.k.rows)
@@ -1398,6 +1408,8 @@ transformTable <- function(data,
         data <- if (isListOrRaggedArray(data)) lapply(data, HideEmptyColumns)
                 else HideEmptyColumns(data)
     }
+    cat("line 1413\n")
+    print(class(data))
 
     # Switching rows and columns
     # This is the first operation performed to ensure that both
@@ -1414,6 +1426,8 @@ transformTable <- function(data,
         if (!is.null(old.span))
             attr(data, "span") <- list(rows = old.span$columns, columns = old.span$rows)
     }
+    cat("line 1431\n")
+    print(class(data))
 
     # Checking sample sizes (if available)
     # This needs to happen after row/columns have been (de)selected
@@ -1435,18 +1449,26 @@ transformTable <- function(data,
         if (!is.null(tmp.names))
             rownames(data) <- tmp.names
     }
+    cat("line 1454\n")
+    print(class(data))
 
     # Convert to matrix to avoid state names from being turned into numeric values
     # when TidyTabularData is called
     if (gsub(" ", "", chart.type) == "GeographicMap" && is.data.frame(data))
         data <- CopyAttributes(as.matrix(data), data)
+    is.qtable <- inherits(data, "QTable")
+    cat("line 1461\n")
+    print(class(data))
 
     # This must happen after sample sizes have been used
     # (only first statistic is retained after tidying)
     if (tidy && !chart.type %in% c("Venn", "Sankey", "Heat") &&
         !isScatter(chart.type) && !isDistribution(chart.type))
             data <- tryCatch(TidyTabularData(data), error = function(e) { data })
-
+    if (is.qtable && !inherits(data, "QTable"))
+        class(data) <- c(class(data), "QTable")
+    cat("line 1466\n")
+    print(class(data))
 
     if (!grepl("^No date", date.format) && date.format != "Automatic")
     {

--- a/R/preparedata.R
+++ b/R/preparedata.R
@@ -567,12 +567,7 @@ PrepareData <- function(chart.type,
     # by converting to a matrix if necessary
     if (chart.type == "Table" && !is.null(attr(data, "statistic")) &&
         (is.null(dim(data)) || length(dim(data)) == 1))
-    {
         data <- CopyAttributes(as.matrix(data), data)
-        #tmp <- attr(data, "statistic")
-        #data <- as.matrix(data)
-        #attr(data, "statistic") <- tmp
-    }
 
     # Modify multi-stat QTables so they are 3 dimensional arrays
     # and statistic attribute from the primary statistic
@@ -1456,7 +1451,6 @@ transformTable <- function(data,
     # when TidyTabularData is called
     if (gsub(" ", "", chart.type) == "GeographicMap" && is.data.frame(data))
         data <- CopyAttributes(as.matrix(data), data)
-    is.qtable <- inherits(data, "QTable")
     cat("line 1461\n")
     print(class(data))
 
@@ -1465,8 +1459,6 @@ transformTable <- function(data,
     if (tidy && !chart.type %in% c("Venn", "Sankey", "Heat") &&
         !isScatter(chart.type) && !isDistribution(chart.type))
             data <- tryCatch(TidyTabularData(data), error = function(e) { data })
-    if (is.qtable && !inherits(data, "QTable"))
-        class(data) <- c(class(data), "QTable")
     cat("line 1466\n")
     print(class(data))
 

--- a/R/preparedata.R
+++ b/R/preparedata.R
@@ -361,6 +361,8 @@ PrepareData <- function(chart.type,
     if (is.data.frame(data))
         names(data) <- if (show.labels) Labels(data) else Names(data)
     chart.title <- attr(data, "title")
+    cat("line 364\n")
+    print(attr(data, "span"))
 
     ###########################################################################
     # 2. Filters the data and/or removes missing values
@@ -403,6 +405,8 @@ PrepareData <- function(chart.type,
     }
     if (filt)
         attr(data, "assigned.rownames") <- FALSE
+    cat("line 408\n")
+    print(attr(data, "span"))
 
     ###########################################################################
     # 3. Aggregate the data if so required.
@@ -428,6 +432,8 @@ PrepareData <- function(chart.type,
         if (crosstab)
             group.by.last <- TRUE
     }
+    cat("line 435\n")
+    print(attr(data, "span"))
 
     ###########################################################################
     # 4. Tailoring the data for the chart type.
@@ -467,6 +473,8 @@ PrepareData <- function(chart.type,
                    hide.output.threshold, hide.values.threshold, hide.rows.threshold, hide.columns.threshold,
                    transpose, group.by.last || first.aggregate,
                    hide.empty.rows, hide.empty.columns, date.format)
+    cat("line 476\n")
+    print(attr(data, "span"))
 
     # Sort must happen AFTER tidying
     data <- RearrangeRowsColumns(data,
@@ -497,6 +505,8 @@ PrepareData <- function(chart.type,
 
     if (scatter.mult.yvals)
         data <- convertScatterMultYvalsToDataFrame(data, input.data.raw, show.labels, date.format)
+    cat("line 508\n")
+    print(attr(data, "span"))
 
     ###########################################################################
     # Finalizing the result.
@@ -572,6 +582,8 @@ PrepareData <- function(chart.type,
         attr(data, "sorted.rows") <- TRUE
     if (!is.null(input.data.table))
         attr(data, "footerhtml") <- attr(input.data.table, "footerhtml", exact = TRUE)
+    cat("line 585\n")
+    print(attr(data, "span"))
 
     list(data = data,
          weights = weights,

--- a/R/preparedata.R
+++ b/R/preparedata.R
@@ -334,8 +334,6 @@ PrepareData <- function(chart.type,
                             input.data.raw, input.data.pasted, input.data.other)
     # Assign the data to 'data'
     data <- processInputData(input.data.table, subset, weights)
-    cat("line 336\n")
-    print(class(data))
     if (is.null(data))
         data <- input.data.tables
     if (is.null(data))
@@ -363,9 +361,6 @@ PrepareData <- function(chart.type,
     if (is.data.frame(data))
         names(data) <- if (show.labels) Labels(data) else Names(data)
     chart.title <- attr(data, "title")
-    cat("line 364\n")
-    print(class(data))
-    print(attr(data, "span"))
 
     ###########################################################################
     # 2. Filters the data and/or removes missing values
@@ -408,9 +403,7 @@ PrepareData <- function(chart.type,
     }
     if (filt)
         attr(data, "assigned.rownames") <- FALSE
-    cat("line 408\n")
-    print(class(data))
-    print(attr(data, "span"))
+
 
     ###########################################################################
     # 3. Aggregate the data if so required.
@@ -436,9 +429,6 @@ PrepareData <- function(chart.type,
         if (crosstab)
             group.by.last <- TRUE
     }
-    cat("line 435\n")
-    print(class(data))
-    print(attr(data, "span"))
 
     ###########################################################################
     # 4. Tailoring the data for the chart type.
@@ -478,9 +468,6 @@ PrepareData <- function(chart.type,
                    hide.output.threshold, hide.values.threshold, hide.rows.threshold, hide.columns.threshold,
                    transpose, group.by.last || first.aggregate,
                    hide.empty.rows, hide.empty.columns, date.format)
-    cat("line 476\n")
-    print(class(data))
-    print(attr(data, "span"))
 
     # Sort must happen AFTER tidying
     data <- RearrangeRowsColumns(data,
@@ -511,9 +498,7 @@ PrepareData <- function(chart.type,
 
     if (scatter.mult.yvals)
         data <- convertScatterMultYvalsToDataFrame(data, input.data.raw, show.labels, date.format)
-    cat("line 508\n")
-    print(class(data))
-    print(attr(data, "span"))
+
 
     ###########################################################################
     # Finalizing the result.
@@ -584,8 +569,6 @@ PrepareData <- function(chart.type,
         attr(data, "sorted.rows") <- TRUE
     if (!is.null(input.data.table))
         attr(data, "footerhtml") <- attr(input.data.table, "footerhtml", exact = TRUE)
-    cat("line 585\n")
-    print(attr(data, "span"))
 
     list(data = data,
          weights = weights,
@@ -1345,9 +1328,6 @@ RearrangeRowsColumns <- function(data,
     data <- RemoveRowsAndOrColumns(data,
                 row.names.to.remove = row.names.to.remove,
                 column.names.to.remove = column.names.to.remove, split = split)
-    cat("after RemoveRowsAndColumns\n")
-    print(class(data))
-    print(attr(data, "span"))
 
     # Keep last to retain order from sorting
     data <- SelectRows(data, first.k = first.k.rows, last.k = last.k.rows)
@@ -1403,8 +1383,6 @@ transformTable <- function(data,
         data <- if (isListOrRaggedArray(data)) lapply(data, HideEmptyColumns)
                 else HideEmptyColumns(data)
     }
-    cat("line 1413\n")
-    print(class(data))
 
     # Switching rows and columns
     # This is the first operation performed to ensure that both
@@ -1421,8 +1399,6 @@ transformTable <- function(data,
         if (!is.null(old.span))
             attr(data, "span") <- list(rows = old.span$columns, columns = old.span$rows)
     }
-    cat("line 1431\n")
-    print(class(data))
 
     # Checking sample sizes (if available)
     # This needs to happen after row/columns have been (de)selected
@@ -1444,23 +1420,18 @@ transformTable <- function(data,
         if (!is.null(tmp.names))
             rownames(data) <- tmp.names
     }
-    cat("line 1454\n")
-    print(class(data))
 
     # Convert to matrix to avoid state names from being turned into numeric values
     # when TidyTabularData is called
     if (gsub(" ", "", chart.type) == "GeographicMap" && is.data.frame(data))
         data <- CopyAttributes(as.matrix(data), data)
-    cat("line 1461\n")
-    print(class(data))
 
     # This must happen after sample sizes have been used
     # (only first statistic is retained after tidying)
     if (tidy && !chart.type %in% c("Venn", "Sankey", "Heat") &&
         !isScatter(chart.type) && !isDistribution(chart.type))
             data <- tryCatch(TidyTabularData(data), error = function(e) { data })
-    cat("line 1466\n")
-    print(class(data))
+
 
     if (!grepl("^No date", date.format) && date.format != "Automatic")
     {

--- a/R/preparedata.R
+++ b/R/preparedata.R
@@ -574,17 +574,15 @@ PrepareData <- function(chart.type,
     if (!is.null(input.data.table))
         attr(data, "footerhtml") <- attr(input.data.table, "footerhtml", exact = TRUE)
 
-    res <- list(data = data,
+    cat("line 577: span:")
+    print(attr(data, "span"))
+    list(data = data,
          weights = weights,
          values.title = values.title,
          categories.title = categories.title,
          chart.title = chart.title,
          chart.footer = attr(data, "footer", exact = TRUE),
          scatter.variable.indices = attr(data, "scatter.variable.indices"))
-    span <- attr(data, "span", exact = TRUE)
-    if (!is.null(span))
-        attr(res, "span") <- span
-    return (res)
 }
 
 replaceDimNames <- function(x, dim, labels)

--- a/R/preparedata.R
+++ b/R/preparedata.R
@@ -1075,7 +1075,7 @@ processInputData <- function(x, subset, weights)
     # Try to use S3 method to extract data
     x <- ExtractChartData(x)
     n.dim <- length(dim(x)) - isQTableWithMultStatistic(x)
-    if (n.dim >= 2)
+    if (n.dim > 2)
         x <- FlattenQTable(x)
 
     if (hasUserSuppliedRownames(x))

--- a/R/preparedata.R
+++ b/R/preparedata.R
@@ -404,7 +404,6 @@ PrepareData <- function(chart.type,
     if (filt)
         attr(data, "assigned.rownames") <- FALSE
 
-
     ###########################################################################
     # 3. Aggregate the data if so required.
     ###########################################################################
@@ -499,7 +498,6 @@ PrepareData <- function(chart.type,
     if (scatter.mult.yvals)
         data <- convertScatterMultYvalsToDataFrame(data, input.data.raw, show.labels, date.format)
 
-
     ###########################################################################
     # Finalizing the result.
     ###########################################################################
@@ -553,9 +551,10 @@ PrepareData <- function(chart.type,
     if (chart.type == "Table" && !is.null(attr(data, "statistic")) &&
         (is.null(dim(data)) || length(dim(data)) == 1))
     {
-        tmp <- attr(data, "statistic")
-        data <- as.matrix(data)
-        attr(data, "statistic") <- tmp
+        data <- CopyAttributes(as.matrix(data), data)
+        #tmp <- attr(data, "statistic")
+        #data <- as.matrix(data)
+        #attr(data, "statistic") <- tmp
     }
 
     # Modify multi-stat QTables so they are 3 dimensional arrays
@@ -574,8 +573,6 @@ PrepareData <- function(chart.type,
     if (!is.null(input.data.table))
         attr(data, "footerhtml") <- attr(input.data.table, "footerhtml", exact = TRUE)
 
-    cat("line 577: span:")
-    print(attr(data, "span"))
     list(data = data,
          weights = weights,
          values.title = values.title,

--- a/tests/testthat/test-preparedata-tidytable.R
+++ b/tests/testthat/test-preparedata-tidytable.R
@@ -407,3 +407,217 @@ tb.relpct <- structure(c(5.00326180684867, 7.285650634158, 8.40518598530936,
 
 })
 
+tb1d.spans <- structure(c(Male = 49.375, Female = 50.625, NET = 100, `18 to 24` = 12.375,
+`25 to 29` = 11.75, `30 to 34` = 10.375, `35 to 39` = 11.375,
+`40 to 44` = 11.625, `45 to 49` = 7.875, `50 to 54` = 11.875,
+`55 to 64` = 15.75, `65 or more` = 7, NET = 100), statistic = "%", dim = 13L, dimnames = list(
+    c("Male", "Female", "NET", "18 to 24", "25 to 29", "30 to 34",
+    "35 to 39", "40 to 44", "45 to 49", "50 to 54", "55 to 64",
+    "65 or more", "NET")), class = c("array", "QTable"), dimnets = list(
+    integer(0)), dimduplicates = list(integer(0)), span = list(
+    rows = structure(list(c("Gender", "Gender", "Gender", "Age",
+    "Age", "Age", "Age", "Age", "Age", "Age", "Age", "Age", "Age"
+    ), c("Male", "Female", "NET", "18 to 24", "25 to 29", "30 to 34",
+    "35 to 39", "40 to 44", "45 to 49", "50 to 54", "55 to 64",
+    "65 or more", "NET")), class = "data.frame", names = c("",
+    ""), row.names = c(NA, 13L))), basedescriptiontext = "sample size = 800", basedescription = list(
+    Minimum = 800L, Maximum = 800L, Range = FALSE, Total = 800L,
+    Missing = 0L, EffectiveSampleSize = 800L, EffectiveSampleSizeProportion = 100,
+    FilteredProportion = 0), QStatisticsTestingInfo = structure(list(
+    significancearrowratio = structure(c(1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1), dim = 13L), significancedirection = structure(c("Up",
+    "Up", "Up", "Down", "Down", "Down", "Down", "Down", "Down",
+    "Down", "Down", "Down", "Up"), dim = 13L), significancefontsizemultiplier = structure(c(4.89,
+    4.89, 4.89, 0.204498977505112, 0.204498977505112, 0.204498977505112,
+    0.204498977505112, 0.204498977505112, 0.204498977505112,
+    0.204498977505112, 0.204498977505112, 0.204498977505112,
+    4.89), dim = 13L), significanceissignificant = structure(c(TRUE,
+    TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE,
+    TRUE, TRUE), dim = 13L), significanceargbcolor = structure(c(-16776961L,
+    -16776961L, -16776961L, -65536L, -65536L, -65536L, -65536L,
+    -65536L, -65536L, -65536L, -65536L, -65536L, -16776961L), dim = 13L),
+    backgroundargbcolor = structure(c(0L, 0L, 0L, 0L, 0L, 0L,
+    0L, 0L, 0L, 0L, 0L, 0L, 0L), dim = 13L), zstatistic = structure(c(11.4020968466331,
+    12.1681291929185, 42.4264068711928, -11.2724606034155, -11.6554767765583,
+    -12.4981123574722, -11.8852864804439, -11.7320800111868,
+    -14.0301770500431, -11.5788735419297, -9.20417326844489,
+    -14.5663996924429, 42.4264068711928), dim = 13L), pcorrected = structure(c(0,
+    0, 0, 1.79482771878254e-29, 2.15172670928116e-31, 7.64449328139232e-36,
+    1.41150291299093e-32, 8.72869765128773e-32, 1.01896870191481e-44,
+    5.27344335539372e-31, 3.44311401819752e-20, 4.59476185309941e-48,
+    0), dim = 13L)), class = "data.frame", row.names = c(NA,
+13L)), questiontypes = "PickAny", footerhtml = "BANNER SUMMARY&lt;br /&gt;sample size = 800; 95% confidence level", name = "BANNER", questions = c("BANNER",
+"SUMMARY"))
+tb2d.with.rowspan <- structure(c(34.8484848484849, 65.1515151515152, 100, 10.6060606060606,
+10.6060606060606, 10.6060606060606, 4.54545454545455, 13.6363636363636,
+15.1515151515152, 10.6060606060606, 15.1515151515152, 9.09090909090909,
+100, 100, 49.5121951219512, 50.4878048780488, 100, 11.7073170731707,
+11.219512195122, 8.78048780487805, 9.02439024390244, 10, 9.26829268292683,
+12.6829268292683, 17.0731707317073, 10.2439024390244, 100, 100,
+52.1604938271605, 47.8395061728395, 100, 13.5802469135802, 12.6543209876543,
+12.3456790123457, 15.7407407407407, 13.2716049382716, 4.62962962962963,
+11.1111111111111, 14.1975308641975, 2.46913580246914, 100, 100,
+49.375, 50.625, 100, 12.375, 11.75, 10.375, 11.375, 11.625, 7.875,
+11.875, 15.75, 7, 100, 100), statistic = "Column %", dim = c(14L,
+4L), dimnames = list(c("Male", "Female", "NET", "18 to 24", "25 to 29",
+"30 to 34", "35 to 39", "40 to 44", "45 to 49", "50 to 54", "55 to 64",
+"65 or more", "NET", "NET"), c("I am on a diet, so I tend to watch what I eat and drink",
+"I tend watch what I eat and drink, but don’t consider myself",
+"I typically eat and drink whatever I feel like", "NET")), class = c("matrix",
+"array", "QTable"), dimnets = list(14L, 4L), dimduplicates = list(
+    14L, 4L), span = list(rows = structure(list(c("Gender", "Gender",
+"Gender", "Age", "Age", "Age", "Age", "Age", "Age", "Age", "Age",
+"Age", "Age", NA), c("Male", "Female", "NET", "18 to 24", "25 to 29",
+"30 to 34", "35 to 39", "40 to 44", "45 to 49", "50 to 54", "55 to 64",
+"65 or more", "NET", "NET")), class = "data.frame", names = c("",
+""), row.names = c(NA, 14L)), columns = structure(list(c("I am on a diet, so I tend to watch what I eat and drink",
+"I tend watch what I eat and drink, but don’t consider myself",
+"I typically eat and drink whatever I feel like", "NET")), class = "data.frame", names = "", row.names = c(NA,
+4L))), basedescriptiontext = "sample size = 800", basedescription = list(
+    Minimum = 800L, Maximum = 800L, Range = FALSE, Total = 800L,
+    Missing = 0L, EffectiveSampleSize = 800L, EffectiveSampleSizeProportion = 100,
+    FilteredProportion = 0), QStatisticsTestingInfo = structure(list(
+    significancearrowratio = structure(c(0.246786632390746, 0,
+    0, 0, 0.246786632390746, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0.246786632390746, 0.465295629820051,
+    0, 0, 0, 0, 0, 0.246786632390746, 0, 0.465295629820051, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0.588688946015424, 0.74293059125964,
+    0, 0, 0, 0, 0, 0, 0, 0, 0), dim = 56L), significancedirection = structure(c("Down",
+    "None", "None", "None", "Up", "None", "None", "None", "None",
+    "None", "None", "None", "None", "None", "None", "None", "None",
+    "None", "None", "None", "None", "None", "None", "None", "None",
+    "Down", "Up", "None", "None", "None", "None", "None", "Up",
+    "None", "Down", "None", "None", "None", "None", "None", "None",
+    "None", "None", "None", "None", "Up", "Down", "None", "None",
+    "None", "None", "None", "None", "None", "None", "None"), dim = 56L),
+    significancefontsizemultiplier = structure(c(0.510204081632653,
+    1, 1, 1, 1.96, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 0.510204081632653, 2.81, 1, 1, 1, 1, 1,
+    1.96, 1, 0.355871886120996, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    3.29, 0.25706940874036, 1, 1, 1, 1, 1, 1, 1, 1, 1), dim = 56L),
+    significanceissignificant = structure(c(TRUE, FALSE, FALSE,
+    FALSE, TRUE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE,
+    FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE,
+    FALSE, FALSE, FALSE, FALSE, TRUE, TRUE, FALSE, FALSE, FALSE,
+    FALSE, FALSE, TRUE, FALSE, TRUE, FALSE, FALSE, FALSE, FALSE,
+    FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, TRUE, TRUE, FALSE,
+    FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE), dim = 56L),
+    significanceargbcolor = structure(c(-65536L, -8355712L, -8355712L,
+    -8355712L, -16776961L, -8355712L, -8355712L, -8355712L, -8355712L,
+    -8355712L, -8355712L, -8355712L, -8355712L, -8355712L, -8355712L,
+    -8355712L, -8355712L, -8355712L, -8355712L, -8355712L, -8355712L,
+    -8355712L, -8355712L, -8355712L, -8355712L, -65536L, -16776961L,
+    -8355712L, -8355712L, -8355712L, -8355712L, -8355712L, -16776961L,
+    -8355712L, -65536L, -8355712L, -8355712L, -8355712L, -8355712L,
+    -8355712L, -8355712L, -8355712L, -8355712L, -8355712L, -8355712L,
+    -16776961L, -65536L, -8355712L, -8355712L, -8355712L, -8355712L,
+    -8355712L, -8355712L, -8355712L, -8355712L, -8355712L), dim = 56L),
+    backgroundargbcolor = structure(c(0L, 0L, 0L, 0L, 0L, 0L,
+    0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L,
+    0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L,
+    0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L,
+    0L, 0L, 0L, 0L, 0L), dim = 56L), zstatistic = structure(c(-2.46430410396057,
+    0.0795806012424474, 1.30011015397555, NaN, 2.46430410396057,
+    -0.0795806012424474, -1.30011015397555, NaN, NaN, NaN, NaN,
+    NaN, -0.455612117101389, -0.588014817629355, 0.854089594757057,
+    NaN, -0.301297589432649, -0.477753340731895, 0.655330441078807,
+    NaN, 0.0642667299386742, -1.51643509388075, 1.5080692220922,
+    NaN, -1.82434472132931, -2.14699644791851, 3.20861889801731,
+    NaN, 0.532228750874652, -1.4702689629657, 1.19878759878797,
+    NaN, 2.29128091462373, 1.50014397827836, -2.81166941935835,
+    NaN, -0.332692826948818, 0.724286306497465, -0.551033295254478,
+    NaN, -0.139346754328631, 1.05340474507031, -0.994515974143204,
+    NaN, 0.695046063335142, 3.68707446075828, -4.14385521918865,
+    NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN), dim = 56L),
+    pcorrected = structure(c(0.0137279582372565, 0.936570824241361,
+    0.19356321801095, NaN, 0.0137279582372565, 0.936570824241361,
+    0.19356321801095, NaN, NaN, NaN, NaN, NaN, 0.648668928213484,
+    0.556522347028733, 0.39305534877777, NaN, 0.763187578923791,
+    0.632825774278165, 0.512255025650413, NaN, 0.948757844333437,
+    0.129409370852577, 0.131536811435796, NaN, 0.0680999734029903,
+    0.0317935644032437, 0.00133374150303678, NaN, 0.594567572401358,
+    0.141488923495995, 0.230610545835739, NaN, 0.0219471717154441,
+    0.133577111123972, 0.00492851278988693, NaN, 0.739366164674592,
+    0.46888998201993, 0.581610850537185, NaN, 0.889176145632785,
+    0.292155530369392, 0.319971732404236, NaN, 0.487026434606843,
+    0.000226846995657892, 0.0000341515402061399, NaN, NaN, NaN,
+    NaN, NaN, NaN, NaN, NaN, NaN), dim = 56L)), class = "data.frame", row.names = c(NA,
+56L)), questiontypes = c("PickAny", "PickOne"), footerhtml = "BANNER by Weight-consciousness&lt;br /&gt;sample size = 800; 95% confidence level", name = "BANNER by Weight-consciousness", questions = c("BANNER",
+"Weight-consciousness"))
+    test_that("Table with Spans", {
+        assign("ALLOW.QTABLE.CLASS", TRUE, envir = .GlobalEnv)
+        res <- PrepareData("Table", input.data.table = tb1d.spans, tidy = FALSE,
+                    row.names.to.remove = "", column.names.to.remove = "")
+        expect_equal(attr(res$data, "span"),
+            list(rows = structure(list(c("Gender", "Gender", "Gender", "Age",
+                "Age", "Age", "Age", "Age", "Age", "Age", "Age", "Age", "Age"
+                ), c("Male", "Female", "NET", "18 to 24", "25 to 29", "30 to 34",
+                "35 to 39", "40 to 44", "45 to 49", "50 to 54", "55 to 64", "65 or more",
+                "NET")), names = c("", ""), row.names = c(NA, 13L), class = "data.frame")))
+
+        res <- PrepareData("Table", input.data.table = tb1d.spans, tidy = FALSE,
+                    sort.rows = TRUE)
+        expect_equal(attr(res$data, "span")$rows,
+            structure(list(c("Age", "Age", "Age", "Age", "Age", "Age", "Age",
+                "Age", "Age", "Gender", "Gender"), c("65 or more", "45 to 49",
+                "30 to 34", "35 to 39", "40 to 44", "25 to 29", "50 to 54", "18 to 24",
+                "55 to 64", "Male", "Female")), names = c("", ""), row.names = c(12L,
+                9L, 6L, 7L, 8L, 5L, 10L, 4L, 11L, 1L, 2L), class = "data.frame"))
+
+        res <- PrepareData("Table", input.data.table = tb1d.spans, tidy = FALSE,
+                    transpose = TRUE, row.names.to.remove = NULL,
+                    column.names.to.remove = NULL)
+        expect_equal(attr(res$data, "span"),
+            list(rows = NULL, columns = structure(list(c("Gender", "Gender",
+                "Gender", "Age", "Age", "Age", "Age", "Age", "Age", "Age", "Age",
+                "Age", "Age"), c("Male", "Female", "NET", "18 to 24", "25 to 29",
+                "30 to 34", "35 to 39", "40 to 44", "45 to 49", "50 to 54", "55 to 64",
+                "65 or more", "NET")), names = c("", ""), row.names = c(NA, 13L
+                ), class = "data.frame")))
+
+        res <- PrepareData("Table", input.data.table = tb1d.spans, tidy = FALSE,
+                    transpose = TRUE)
+        # Currently losing column spans
+
+        res <- PrepareData("Table", input.data.table = tb2d.with.rowspan, tidy = FALSE)
+        expect_equal(attr(res$data, "span"),
+            list(rows = structure(list(c("Gender", "Gender", "Age", "Age",
+                "Age", "Age", "Age", "Age", "Age", "Age", "Age"), c("Male", "Female",
+                "18 to 24", "25 to 29", "30 to 34", "35 to 39", "40 to 44", "45 to 49",
+                "50 to 54", "55 to 64", "65 or more")), names = c("", ""), row.names = c(1L,
+                2L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L, 12L), class = "data.frame"),
+                columns = structure(list(c("I am on a diet, so I tend to watch what I eat and drink",
+                "I tend watch what I eat and drink, but don’t consider myself",
+                "I typically eat and drink whatever I feel like")), names = "",
+                row.names = c(NA, 3L), class = "data.frame")))
+
+        res <- PrepareData("Table", input.data.table = tb2d.with.rowspan, tidy = FALSE,
+                transpose = TRUE, column.names.to.remove = "NET, 65 or more")
+        expect_equal(attr(res$data, "span"),
+             list(rows = structure(list(c("I am on a diet, so I tend to watch what I eat and drink",
+                "I tend watch what I eat and drink, but don’t consider myself",
+                "I typically eat and drink whatever I feel like")), names = "", row.names = c(NA,
+                3L), class = "data.frame"), columns = structure(list(c("Gender",
+                "Gender", "Age", "Age", "Age", "Age", "Age", "Age", "Age", "Age"
+                ), c("Male", "Female", "18 to 24", "25 to 29", "30 to 34", "35 to 39",
+            "40 to 44", "45 to 49", "50 to 54", "55 to 64")), names = c("",
+            ""), row.names = c(1L, 2L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L), class = "data.frame")))
+
+
+        res <- PrepareData("Table", input.data.table = tb2d.with.rowspan, tidy = FALSE,
+                           first.k.rows = 5)
+        expect_equal(attr(res$data, "span")$rows, structure(list(c("Gender",
+                "Gender", "Age", "Age", "Age"), c("Male", "Female",
+                "18 to 24", "25 to 29", "30 to 34")), names = c("", ""),
+                row.names = c(1L, 2L, 4L, 5L, 6L), class = "data.frame"))
+
+        expect_warning(res <- PrepareData("Table", input.data.table = tb2d.with.rowspan,
+                tidy = FALSE, sort.rows = TRUE, sort.rows.column = 1))
+        expect_equal(attr(res$data, "span")$rows, structure(list(c("Age",
+                "Age", "Age", "Age", "Age", "Age", "Age", "Age", "Age", "Gender", "Gender"),
+                c("35 to 39", "65 or more", "18 to 24", "25 to 29", "30 to 34",
+                 "50 to 54", "40 to 44", "45 to 49", "55 to 64", "Male", "Female")),
+                names = c("", ""), row.names = c(7L, 12L, 4L, 5L, 6L, 10L, 8L, 9L, 11L, 1L, 2L),
+                class = "data.frame"))
+    remove(ALLOW.QTABLE.CLASS, envir = .GlobalEnv)
+})


### PR DESCRIPTION
Most of the work to preserve spans is already done in the [verbs](https://github.com/Displayr/verbs/blob/master/R/table-subscript.R) package. This change is mostly just trying to keep the QTable class and span attribute from getting lost. It also updates the span attribute when the table is transposed