### PR TITLE
FS2-2893: Add column comparisons

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ parameters:
     default: ""
   remote-deps:
     type: string
-    default: ""
+    default: Displayr/rhtmlCombinedScatter@1.0.14,Displayr/flipStandardCharts@1.31.6
   plugins-branch:
     type: string
     default: ""

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,4 +44,4 @@ Remotes:
     Displayr/flipTime,
     Displayr/flipU,
     Displayr/verbs
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipChart
 Type: Package
 Title: Single function for calling charts - CChart
-Version: 1.11.1
+Version: 1.12.0
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Wrapper for other chart functions, such that they can be access via a

--- a/R/cchart.R
+++ b/R/cchart.R
@@ -24,7 +24,7 @@
 #'     \itemize{\code{fit.type} }{ Character; type of line of best fit. Can be one of "None", "Linear", "LOESS",
 #'          "Friedman's super smoother" or "Cubic spline". This option is only valid for charts Area, Bar, Column, Line, Scatter, Pyramid.}
 #'     \itemize{\code{fit.ignore.last} }{ Logical; whether to ignore the last data point in the fit.}
-#'     \itemize{\code{fit.line.type} }{ Character; One of "solid", "dot", "dash, "dotdash", or length of dash "2px", "5px".}
+#'     \itemize{\code{fit.line.type} }{ Character; One of "solid", "dot", "dash", "dotdash", or length of dash "2px", "5px".}
 #'     \itemize{\code{fit.line.colors} }{ Character; a vector containing one or more colors specified as hex codes.}
 #'     \itemize{\code{fit.line.width} }{ Numeric; Line width of line of best fit.}
 #'     \itemize{\code{fit.line.name} }{ Character; Name of the line of best fit, which will appear in the hovertext.}
@@ -289,8 +289,6 @@ CChart <- function(chart.type, x, small.multiples = FALSE,
 
     if (signif.show)
     {
-        x.ndim <- length(dim(x))
-        x.data.names <- dimnames(x)[[x.ndim]]
         if (!isTRUE(user.args$data.label.show))
         {
             # If data label show is false, then other annotations are not shown
@@ -309,6 +307,8 @@ CChart <- function(chart.type, x, small.multiples = FALSE,
         annot.len <- length(annotation.list)
         if (signif.column.comparisons)
         {
+            x.ndim <- length(dim(x))
+            x.data.names <- dimnames(x)[[x.ndim]]
             if ("Column Comparisons" %in% x.data.names)
             {
                 # Note that even if data labels are not shown, default font settings
@@ -331,7 +331,6 @@ CChart <- function(chart.type, x, small.multiples = FALSE,
             # Add arrow annotations which have been attached as an
             # attribute to x in PrepareData
             # Only show arrows if not showing column comparisons
-            annot.len <- length(annotation.list)
             new.len <- length(attr(x, "signif.annotations"))
             for (j in 1:new.len)
                 annotation.list[[annot.len + j]] <- attr(x, "signif.annotations")[[j]]

--- a/R/cchart.R
+++ b/R/cchart.R
@@ -6,7 +6,8 @@
 #' @param multi.color.series Logical; Indicates whether multiple colors will be shown in a Bar or Column chart with a single series. By default this is off and different colors are used to distinguish between different series. However, when chart.type is "Pyramid", then \code{multi.color.series} is always \code{true}.
 #' @param font.units One of "px" or "pt"
 #' @param annotation.list a list of annotations to add to the chart, based on statistics in the input data.
-#' @param signif.show Logical; whether to show significance tests.
+#' @param signif.show Logical; whether to show significance tests (arrows or column comparisons).
+#' @param signif.column.comparisons; whether to show comparisons (letters) in data labels.
 #' @param ... Arguments to the function \code{chart.type}. See documentation for specific chart types or see details below.
 #' @param warn.if.no.match Logical; If TRUE, a warning is shown if any arugments are not matched.
 #' @param append.data Logical; If TRUE, extra information is appended to the chart object which is used for exporting. These are appended as attributes
@@ -265,7 +266,8 @@
 #' CChart("Area", x, small.multiples = TRUE,  colors = rainbow(3), categories.title = "Categories")
 CChart <- function(chart.type, x, small.multiples = FALSE,
                    multi.color.series = FALSE, font.units = "px",
-                   annotation.list = NULL, signif.show = FALSE, signif.column.comparison,
+                   annotation.list = NULL, signif.show = FALSE,
+                   signif.column.comparisons = FALSE,
                    ..., warn.if.no.match = TRUE, append.data = FALSE)
 {
     if (chart.type %in% c("Venn"))
@@ -305,20 +307,25 @@ CChart <- function(chart.type, x, small.multiples = FALSE,
                 )
         }
         annot.len <- length(annotation.list)
-        if (signif.column.comparison && "Column Comparisons" %in% x.data.names)
+        if (signif.column.comparisons)
         {
-            annotation.list[[annot.len + 1]] <- list(
-                    type = "Text - after data label",
-                    data = "Column Comparisons",
-                    threstype = "above threshold",
-                    threshold = "",
-                    format = "Category",
-                    prefix = "&nbsp;",
-                    suffix = "",
-                    color = "red", #user.args$data.label.color,
-                    size = user.args$data.label.color, # what if no data labels??
-                    font.family = user.args$data.label.font.family
-            )
+            if ("Column Comparisons" %in% x.data.names)
+            {
+                # Note that even if data labels are not shown, default font settings
+                # are passed to CChart, i.e. https://github.com/Displayr/Plugins/blob/master/src/Standard%20R/Visualization/Area/Area.R#L400
+                annotation.list[[annot.len + 1]] <- list(
+                        type = "Text - after data label",
+                        data = "Column Comparisons",
+                        threstype = "above threshold",
+                        threshold = "",
+                        format = "",
+                        prefix = "&nbsp;",
+                        suffix = "",
+                        color = user.args$data.label.color,
+                        size = user.args$data.label.color,
+                        font.family = user.args$data.label.font.family
+                )
+            }
         } else if (!is.null(attr(x, "signif.annotations")))
         {
             # Add arrow annotations which have been attached as an
@@ -332,7 +339,6 @@ CChart <- function(chart.type, x, small.multiples = FALSE,
         }
     }
     user.args$annotation.list <- annotation.list
-
     chart.function <- gsub(" ", "", chart.type)             # spaces always removed
     fun.and.pars <- getFunctionAndParameters(chart.function, small.multiples)
     if (tolower(font.units) %in% c("pt", "points"))

--- a/R/cchart.R
+++ b/R/cchart.R
@@ -7,7 +7,7 @@
 #' @param font.units One of "px" or "pt"
 #' @param annotation.list a list of annotations to add to the chart, based on statistics in the input data.
 #' @param signif.show Logical; whether to show significance tests (arrows or column comparisons).
-#' @param signif.column.comparisons; whether to show comparisons (letters) in data labels.
+#' @param signif.column.comparisons Logical; whether to show comparisons (letters) in data labels.
 #' @param ... Arguments to the function \code{chart.type}. See documentation for specific chart types or see details below.
 #' @param warn.if.no.match Logical; If TRUE, a warning is shown if any arugments are not matched.
 #' @param append.data Logical; If TRUE, extra information is appended to the chart object which is used for exporting. These are appended as attributes
@@ -17,7 +17,7 @@
 #' \item{ChartType}{This attribute is actually always set, even if \code{append.data} if not true. It is the name of the chart type as used in PowerPoint and can vary depending on the visualization settings used.}}
 #' @details Parameters passed to the charting functions are listed below:
 #' \describe{
-#'     \itemize{\code{type} }{ For chart types \code{Area}, \code{Bar} and \code{Column}, this can be set to \code{"Stacked"} to show cumulative values.}
+#'     \itemize{\code{type} }{ For chart types \code{Area}, \code{Bar} and \code{Column}, this can be set to \code{Stacked} to show cumulative values.}
 #'     \itemize{\code{grid.show} }{ Logical; whether to show grid lines.}
 #'     \itemize{\code{opacity} }{ Opacity of bars as an alpha value (0 to 1).}
 #'     \itemize{\code{colors} }{ Character; a vector containing one or more colors specified as hex codes.}

--- a/man/CChart.Rd
+++ b/man/CChart.Rd
@@ -12,6 +12,7 @@ CChart(
   font.units = "px",
   annotation.list = NULL,
   signif.show = FALSE,
+  signif.column.comparisons = FALSE,
   ...,
   warn.if.no.match = TRUE,
   append.data = FALSE
@@ -30,7 +31,7 @@ CChart(
 
 \item{annotation.list}{a list of annotations to add to the chart, based on statistics in the input data.}
 
-\item{signif.show}{Logical; whether to show significance tests.}
+\item{signif.show}{Logical; whether to show significance tests (arrows or column comparisons).}
 
 \item{...}{Arguments to the function \code{chart.type}. See documentation for specific chart types or see details below.}
 
@@ -41,6 +42,8 @@ CChart(
 \item{ChartSettings}{This a named list so that powerpoint chart can use the same visualization settings. Information about the structure of this list is \href{https://wiki.q-researchsoftware.com/wiki/PptChartSettings}{here}.}
 \item{ChartWarning}{This attribute is set if the chart cannot be properly exported to Excel. It is set to a string which is shown as a warning message on export in Displayr.}
 \item{ChartType}{This attribute is actually always set, even if \code{append.data} if not true. It is the name of the chart type as used in PowerPoint and can vary depending on the visualization settings used.}}}
+
+\item{signif.column.comparisons;}{whether to show comparisons (letters) in data labels.}
 }
 \value{
 A chart object that can be printed. Most often, a plotly object.

--- a/man/CChart.Rd
+++ b/man/CChart.Rd
@@ -61,7 +61,7 @@ Parameters passed to the charting functions are listed below:
     \itemize{\code{fit.type} }{ Character; type of line of best fit. Can be one of "None", "Linear", "LOESS",
          "Friedman's super smoother" or "Cubic spline". This option is only valid for charts Area, Bar, Column, Line, Scatter, Pyramid.}
     \itemize{\code{fit.ignore.last} }{ Logical; whether to ignore the last data point in the fit.}
-    \itemize{\code{fit.line.type} }{ Character; One of "solid", "dot", "dash, "dotdash", or length of dash "2px", "5px".}
+    \itemize{\code{fit.line.type} }{ Character; One of "solid", "dot", "dash", "dotdash", or length of dash "2px", "5px".}
     \itemize{\code{fit.line.colors} }{ Character; a vector containing one or more colors specified as hex codes.}
     \itemize{\code{fit.line.width} }{ Numeric; Line width of line of best fit.}
     \itemize{\code{fit.line.name} }{ Character; Name of the line of best fit, which will appear in the hovertext.}

--- a/man/CChart.Rd
+++ b/man/CChart.Rd
@@ -33,6 +33,8 @@ CChart(
 
 \item{signif.show}{Logical; whether to show significance tests (arrows or column comparisons).}
 
+\item{signif.column.comparisons}{Logical; whether to show comparisons (letters) in data labels.}
+
 \item{...}{Arguments to the function \code{chart.type}. See documentation for specific chart types or see details below.}
 
 \item{warn.if.no.match}{Logical; If TRUE, a warning is shown if any arugments are not matched.}
@@ -42,8 +44,6 @@ CChart(
 \item{ChartSettings}{This a named list so that powerpoint chart can use the same visualization settings. Information about the structure of this list is \href{https://wiki.q-researchsoftware.com/wiki/PptChartSettings}{here}.}
 \item{ChartWarning}{This attribute is set if the chart cannot be properly exported to Excel. It is set to a string which is shown as a warning message on export in Displayr.}
 \item{ChartType}{This attribute is actually always set, even if \code{append.data} if not true. It is the name of the chart type as used in PowerPoint and can vary depending on the visualization settings used.}}}
-
-\item{signif.column.comparisons;}{whether to show comparisons (letters) in data labels.}
 }
 \value{
 A chart object that can be printed. Most often, a plotly object.
@@ -54,7 +54,7 @@ Creates charts
 \details{
 Parameters passed to the charting functions are listed below:
 \describe{
-    \itemize{\code{type} }{ For chart types \code{Area}, \code{Bar} and \code{Column}, this can be set to \code{"Stacked"} to show cumulative values.}
+    \itemize{\code{type} }{ For chart types \code{Area}, \code{Bar} and \code{Column}, this can be set to \code{Stacked} to show cumulative values.}
     \itemize{\code{grid.show} }{ Logical; whether to show grid lines.}
     \itemize{\code{opacity} }{ Opacity of bars as an alpha value (0 to 1).}
     \itemize{\code{colors} }{ Character; a vector containing one or more colors specified as hex codes.}

--- a/tests/testthat/test-cchart-standardcharts.R
+++ b/tests/testthat/test-cchart-standardcharts.R
@@ -106,23 +106,25 @@ for (input in list( RawData.XFactor,  RawData.XFactor.YFactor, RawData.XPickAny,
     {
         pd <- suppressWarnings(PrepareData(chart.type, input.data.raw = input, first.aggregate = FALSE,
                                            show.labels = FALSE))
-        c = suppressWarnings(CChart( chart.type, pd$data, y.zero = FALSE, y.zero.line.width = 1,  grid.show = FALSE, y.title = "Dog"))
-        #suppressWarnings(print(c))
+        c = suppressWarnings(CChart(chart.type, pd$data, y.zero = FALSE, y.zero.line.width = 1,  grid.show = FALSE, y.title = "Dog"))
         expect_error(suppressWarnings(print(c)), NA)
      }
 
 # Raw data inputs - first aggregate = TRUE
-for (input in list( RawData.XFactor,  RawData.XFactor.YFactor, RawData.XPickAny, RawData.XPickOneMulti, RawData.XNumberMulti))
+for (input in list( RawData.XFactor,  #RawData.XFactor.YFactor,
+                    RawData.XPickAny, RawData.XPickOneMulti, RawData.XNumberMulti))
     for (chart.type in c("Line", "Bar", "Area", "Column"))
     {
         pd <- suppressWarnings(PrepareData(chart.type, input.data.raw = input, first.aggregate = TRUE))
-        c = (CChart( chart.type, pd$data, y.zero = FALSE, y.zero.line.width = 1,  grid.show = FALSE, y.title = "Dog"))
+        c <- CChart(chart.type, pd$data, y.zero = FALSE, y.zero.line.width = 1,  grid.show = FALSE, y.title = "Dog")
         expect_error(print(c), NA)
     }
+    pd <- suppressWarnings(PrepareData(chart.type, input.data.raw = RawData.XFactor.YFactor, first.aggregate = TRUE))
+    expect_warning(c <- CChart("Column", pd$data, y.zero = FALSE,
+            y.zero.line.width = 1,  grid.show = FALSE, y.title = "Dog",), "Missing values")
 
 # Raw data inputs - first aggregate = TRUE, as.percentages = TRUE
-    for (input in list( RawData.XFactor,  RawData.XFactor.YFactor, RawData.XPickAny,
-                       RawData.XPickOneMulti, RawData.XNumberMulti))
+for (input in list(RawData.XFactor, RawData.XPickAny, RawData.XPickOneMulti, RawData.XNumberMulti))
     for (chart.type in c("Line", "Bar", "Area", "Column"))
     {
         pd <- suppressWarnings(PrepareData(chart.type, input.data.raw = input,

--- a/tests/testthat/test-cchart-standardcharts.R
+++ b/tests/testthat/test-cchart-standardcharts.R
@@ -111,7 +111,7 @@ for (input in list( RawData.XFactor,  RawData.XFactor.YFactor, RawData.XPickAny,
      }
 
 # Raw data inputs - first aggregate = TRUE
-for (input in list( RawData.XFactor,  #RawData.XFactor.YFactor,
+for (input in list( RawData.XFactor,  RawData.XFactor.YFactor,
                     RawData.XPickAny, RawData.XPickOneMulti, RawData.XNumberMulti))
     for (chart.type in c("Line", "Bar", "Area", "Column"))
     {
@@ -119,9 +119,6 @@ for (input in list( RawData.XFactor,  #RawData.XFactor.YFactor,
         c <- CChart(chart.type, pd$data, y.zero = FALSE, y.zero.line.width = 1,  grid.show = FALSE, y.title = "Dog")
         expect_error(print(c), NA)
     }
-    pd <- suppressWarnings(PrepareData(chart.type, input.data.raw = RawData.XFactor.YFactor, first.aggregate = TRUE))
-    expect_warning(c <- CChart("Column", pd$data, y.zero = FALSE,
-            y.zero.line.width = 1,  grid.show = FALSE, y.title = "Dog",), "Missing values")
 
 # Raw data inputs - first aggregate = TRUE, as.percentages = TRUE
 for (input in list(RawData.XFactor, RawData.XPickAny, RawData.XPickOneMulti, RawData.XNumberMulti))

--- a/tests/testthat/test-chartsettings-combinedscatter.R
+++ b/tests/testthat/test-chartsettings-combinedscatter.R
@@ -247,7 +247,7 @@ dat.with.factors <- structure(list(Income = structure(c(7L, 4L, 7L, 2L, NA, 3L, 
     class = "data.frame")
 test_that("Exporting scatter with factor data",
 {
-    expect_error(CChart("CombinedScatter", dat.with.factors, colors = ChartColors(10),
-           scatter.colors.column = 2, append.data = TRUE), NA)
+    expect_warning(CChart("CombinedScatter", dat.with.factors, colors = ChartColors(10),
+           scatter.colors.column = 2, append.data = TRUE), "missing values")
 })
 

--- a/tests/testthat/test-stattesting.R
+++ b/tests/testthat/test-stattesting.R
@@ -807,11 +807,10 @@ test_that("QStatisticsTestingInfo rearranges with data manipulations",
 
 test_that("Handle Column Comparisons correctly",
 {
-    expect_warning(viz <- CChart("Line", tb.2d.colcmp,
+    expect_error(viz <- CChart("Line", tb.2d.colcmp,
               legend.orientation = "Horizontal", legend.x.position = 0.5,
               legend.y.position = 1.2, data.label.show = FALSE,
-              signif.show = TRUE, append.data = TRUE),
-              "These tests do not compare columns")
+              signif.show = TRUE, append.data = TRUE), NA)
     chart.data <- attr(viz, "ChartData")
     expect_true(is.numeric(chart.data))
     expect_equal(dimnames(chart.data), list(c("January 2019", "February 2019",
@@ -845,4 +844,10 @@ test_that("Handle Column Comparisons correctly",
     expect_true(is.numeric(chart.data))
     expect_equal(dimnames(chart.data)[1:2], dimnames(tb.multstats.colcmp)[1:2])
     expect_equal(dimnames(chart.data)[[3]], dimnames(tb.multstats.colcmp)[[3]][-4])
+
+    expect_error(viz <- CChart("Bar", tb.2d.colcmp, data.label.show = FALSE,
+            signif.show = TRUE, signif.column.comparisons = TRUE), NA)
+    expect_error((viz <- CChart("Column", tb.2d.colcmp[,,1,drop=FALSE],
+            signif.show = TRUE, signif.column.comparisons = TRUE,
+            data.label.show = TRUE)), NA)
 })


### PR DESCRIPTION
These add the letters with a space, not a new line because it most cases it looks better
<img width="688" alt="Screenshot 2024-09-09 at 2 33 29 PM" src="https://github.com/user-attachments/assets/5de936e4-25db-41bc-8b89-78a9cd24bf92">
<img width="683" alt="Screenshot 2024-09-09 at 2 32 46 PM" src="https://github.com/user-attachments/assets/66ed5e5c-ee65-4ade-adbf-8714e6a5ee18">
 
compared to the legacy column comparisons
<img width="612" alt="Screenshot 2024-09-09 at 2 37 18 PM" src="https://github.com/user-attachments/assets/2b7ee54f-1920-43e2-a5cf-de92cd02585f">

