### PR TITLE
RS-18532: Fix axis position when exporting BarMultiColor

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipChart
 Type: Package
 Title: Single function for calling charts - CChart
-Version: 1.12.4
+Version: 1.12.5
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Wrapper for other chart functions, such that they can be access via a

--- a/R/cchart.R
+++ b/R/cchart.R
@@ -873,7 +873,7 @@ getPPTSettings <- function(chart.type, args, data)
             res$ValueAxis$Minimum <- args$values.bounds.minimum
 
         # This needs to be NULL because powerpoint reverses the bar chart y-axis
-        if (chart.type == "Bar")
+        if (chart.type %in% c("Bar", "BarMultiColor"))
             res$ValueAxis$Crosses <- NULL
 
         # We don't want to manually set axis label position

--- a/tests/testthat/test-chartsettings.R
+++ b/tests/testthat/test-chartsettings.R
@@ -71,6 +71,10 @@ test_that("Chart settings",
             Style = "Solid"), MajorGridLine = list(Color = "#CCCCCC",
             Width = 0.750018750468762, Style = "Solid")))
     expect_equal(attr(res, "ChartSettings")$GapWidth, 0)
+    expect_true(is.null(attr(res, "ChartSettings")$ValueAxis$Crosses))
+
+    res <- CChart("BarMultiColor", dat.1d, append.data = TRUE, colors = col.1d.multicolor)
+    expect_true(is.null(attr(res, "ChartSettings")$ValueAxis$Crosses))
 
     res <- CChart("Column", abs(dat.2d), append.data = TRUE, colors = col.2d.gradient,
             values.grid.width = 1, categories.grid.width = 0,


### PR DESCRIPTION
The fix for the axis position needs to be applied to BarMultiColor which is a separate chart type to Bar.