### PR TITLE
RS-18683: Some additional fixes for Standard R Tests

### DIFF
--- a/R/preparedata.R
+++ b/R/preparedata.R
@@ -503,8 +503,12 @@ PrepareData <- function(chart.type,
     ###########################################################################
     # Finalizing the result.
     ###########################################################################
-
-
+    if (chart.type == "Heat" && inherits(data, "QTable"))
+    {
+        # Remove QTable class for heatmap to avoid problems with column binding
+        data.class <- class(data)
+        class(data) <- setdiff(data.class, "QTable")
+    }
     if (!inherits(data, "QTable") && !is.null(attr(data, "span")))
         attr(data, "span") <- NULL
     if (tidy.labels)

--- a/R/preparedata.R
+++ b/R/preparedata.R
@@ -1419,9 +1419,13 @@ transformTable <- function(data,
                 attr(data, "span") <- list(rows = old.span$columns, columns = old.span$rows)
         } else {
             # Attributes handled by verbs (for QTables)
+            stat.attr <- attr(dat, "statistic")
             data <- t(data)
-            if (!inherits(data, "QTable")) 
+            if (!inherits(data, "QTable"))
+            {
                 attr(data, "questions") <- rev(attr(data, "questions"))
+                attr(data, "statistic") <- stat.attr
+            }
         }
     }
 

--- a/R/preparedata.R
+++ b/R/preparedata.R
@@ -554,12 +554,7 @@ PrepareData <- function(chart.type,
     # by converting to a matrix if necessary
     if (chart.type == "Table" && !is.null(attr(data, "statistic")) &&
         (is.null(dim(data)) || length(dim(data)) == 1))
-    {
-        is.qtable <- inherits(data, "QTable")
         data <- CopyAttributes(as.matrix(data), data)
-        if (is.qtable)
-            class(data) <- c(class(data), "QTable")
-    }
 
     # Modify multi-stat QTables so they are 3 dimensional arrays
     # and statistic attribute from the primary statistic

--- a/R/preparedata.R
+++ b/R/preparedata.R
@@ -1426,15 +1426,17 @@ transformTable <- function(data,
             attr(data, "questions") <- rev(attr(data, "questions"))
             if (!is.null(old.span))
                 attr(data, "span") <- list(rows = old.span$columns, columns = old.span$rows)
-        } else {
+        } else if (inherits(data, "QTable"))
+        {
             # Attributes handled by verbs (for QTables)
-            stat.attr <- attr(data, "statistic")
             data <- t(data)
-            if (!inherits(data, "QTable"))
-            {
-                attr(data, "questions") <- rev(attr(data, "questions"))
-                attr(data, "statistic") <- stat.attr
-            }
+
+        } else
+        {
+            # Handle attributes ourself
+            new.data <- t(data)
+            data <- CopyAttributes(new.data, data)
+            attr(data, "questions") <- rev(attr(data, "questions"))
         }
     }
 

--- a/R/preparedata.R
+++ b/R/preparedata.R
@@ -1419,7 +1419,7 @@ transformTable <- function(data,
                 attr(data, "span") <- list(rows = old.span$columns, columns = old.span$rows)
         } else {
             # Attributes handled by verbs (for QTables)
-            stat.attr <- attr(dat, "statistic")
+            stat.attr <- attr(data, "statistic")
             data <- t(data)
             if (!inherits(data, "QTable"))
             {

--- a/R/preparedata.R
+++ b/R/preparedata.R
@@ -558,7 +558,12 @@ PrepareData <- function(chart.type,
     # by converting to a matrix if necessary
     if (chart.type == "Table" && !is.null(attr(data, "statistic")) &&
         (is.null(dim(data)) || length(dim(data)) == 1))
+    {
+        is.qtable <- inherits(data, "QTable")
         data <- CopyAttributes(as.matrix(data), data)
+        if (is.qtable)
+            class(data) <- c(class(data), "QTable")
+    }
 
     # Modify multi-stat QTables so they are 3 dimensional arrays
     # and statistic attribute from the primary statistic

--- a/tests/testthat/test-preparedata-tidytable.R
+++ b/tests/testthat/test-preparedata-tidytable.R
@@ -743,5 +743,8 @@ test_that("Table with Spans", {
                "I typically eat and drink whatever I feel like", "Male")), names = c("",
                ""), row.names = c(1L, 2L, 3L, 5L), class = "data.frame")))
 
+        expect_error(res <- PrepareData("Heat", input.data.table = tb2d.with.rowspan), NA)
+        expect_equal(class(res$data), c("matrix", "array"))
+
         remove(ALLOW.QTABLE.CLASS, envir = .GlobalEnv)
 })


### PR DESCRIPTION
* Drop QTable class when preparing data for Heat map to avoid problems with binding additional columns
* Separate out the QTable and non-QTable case for transpose. In the non-QTable case, the code has reverted to before the first RS-18683 commit.