### PR TITLE
RS-18536: Fix up axis crossing attribute for export

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipChart
 Type: Package
 Title: Single function for calling charts - CChart
-Version: 1.12.7
+Version: 1.12.8
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Wrapper for other chart functions, such that they can be access via a

--- a/R/cchart.R
+++ b/R/cchart.R
@@ -828,7 +828,7 @@ getPPTSettings <- function(chart.type, args, data)
         # Note that for Area, Bar, Column, Line the zero line of the values axis is shown by default
         values.axis.line <- if (!isTRUE(args$categories.zero.line.width > 0)) list(width = args$values.line.width, color = args$values.line.color, crosses = "Minimum")
                             else list(width = args$categories.zero.line.width, color = args$categories.zero.line.color, dash = args$categories.zero.line.dash, crosses = "AutoZero")
-        categories.axis.line <- if (!isTRUE(args$values.zero.line.width > 0)) list(width = args$categories.line.width, color = args$categories.line.color, crosses = "Minimum")
+        categories.axis.line <- if (!isTRUE(args$values.zero.line.width > 0)) list(width = args$categories.line.width, color = args$categories.line.color, crosses = "AutoZero")
                                 else list(width = args$values.zero.line.width, color = args$values.zero.line.color, dash = args$values.zero.line.dash, crosses = "AutoZero")
 
         res$PrimaryAxis = list(LabelsFont = list(color = args$categories.tick.font.color,

--- a/R/cchart.R
+++ b/R/cchart.R
@@ -828,7 +828,8 @@ getPPTSettings <- function(chart.type, args, data)
         # Note that for Area, Bar, Column, Line the zero line of the values axis is shown by default
         values.axis.line <- if (!isTRUE(args$categories.zero.line.width > 0)) list(width = args$values.line.width, color = args$values.line.color, crosses = "Minimum")
                             else list(width = args$categories.zero.line.width, color = args$categories.zero.line.color, dash = args$categories.zero.line.dash, crosses = "AutoZero")
-        categories.axis.line <- if (!isTRUE(args$values.zero.line.width > 0)) list(width = args$categories.line.width, color = args$categories.line.color, crosses = "AutoZero")
+        default.cross <- if (isScatter(chart.type)) "Minimum" else "AutoZero"
+        categories.axis.line <- if (!isTRUE(args$values.zero.line.width > 0)) list(width = args$categories.line.width, color = args$categories.line.color, crosses = default.cross)
                                 else list(width = args$values.zero.line.width, color = args$values.zero.line.color, dash = args$values.zero.line.dash, crosses = "AutoZero")
 
         res$PrimaryAxis = list(LabelsFont = list(color = args$categories.tick.font.color,

--- a/tests/testthat/test-chartsettings.R
+++ b/tests/testthat/test-chartsettings.R
@@ -97,7 +97,7 @@ test_that("Chart settings",
             TitleFont = list(color = NULL, family = NULL, size = numeric(0)),
             NumberFormat = "General",
             AxisLine = list(Color = "#222222", Width = 1.50003750093752,
-            Style = "Solid"), Crosses = "Minimum", MajorGridLine = list(Color = "#BBBBBB",
+            Style = "Solid"), Crosses = "AutoZero", MajorGridLine = list(Color = "#BBBBBB",
             Width = 0, Style = "None"), RotateLabels = TRUE, LabelPosition = "Low"))
     expect_equal(attr(res, "ChartSettings")$ValueAxis, list(
             LabelsFont = list(color = NULL, family = NULL, size = numeric(0)),
@@ -242,6 +242,12 @@ test_that("Chart settings",
         append.data = TRUE)
     expect_equal(attr(res, "ChartSettings")$PrimaryAxis$Crosses, "AutoZero")
     expect_equal(attr(res, "ChartSettings")$ValueAxis$Crosses, "AutoZero")
+
+    res <- CChart("CombinedScatter", abs(dat.2d) + 10,
+        values.line.width = 2, categories.line.width = 2,
+        append.data = TRUE)
+    expect_equal(attr(res, "ChartSettings")$PrimaryAxis$Crosses, "Minimum")
+    expect_equal(attr(res, "ChartSettings")$ValueAxis$Crosses, "Minimum")
 })
 
 test_that("Scatter axes bounds",


### PR DESCRIPTION
Some more examples in the jira: https://numbers.atlassian.net/browse/RS-18888, but mainly the problem can be seen in 
![image](https://github.com/user-attachments/assets/2cbef2fc-1833-49e6-9e3c-e039bc566a88)
after fix:
![image](https://github.com/user-attachments/assets/6a3a647a-25c6-4f24-84a1-50edf61e3e80)

Another example:
![image](https://github.com/user-attachments/assets/86b9782a-7063-4c3c-94ea-7b9a2bc91015)
after fix:

![image](https://github.com/user-attachments/assets/b474ff95-e5b0-4810-aff9-a5f93233daa6)

